### PR TITLE
Fix overlapping of headers with feedback button

### DIFF
--- a/.sphinx/_static/custom.css
+++ b/.sphinx/_static/custom.css
@@ -199,6 +199,30 @@ body[data-theme="dark"] .sphinx-tabs-tab {
     background: var(--color-background-primary);
 }
 
+/** Make sure the feedback button container renders in the correct location**/
+.content-icon-container {
+    width: 100%;
+    margin: 10px;
+    padding: 10px;
+    box-sizing: border-box;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.article-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+h1 {
+    display: flex;
+    clear: both;
+    width: 100%;
+    margin-top: 10px;
+}
+
 .sphinx-tabs-tab, .sd-tab-set>label{
     color: var(--color-brand-primary);
     font-family: var(--font-stack);


### PR DESCRIPTION
Due to some weird spacing in the default layout, even page titles that should fit on one line often get broken so that the header line overlaps with the feedback button line, so that the layout looks quite varied across pages. This CSS tweak should fix the problem.