### PR TITLE
Consolidate code snippets on virtualization pages

### DIFF
--- a/docs/explanation/using-qemu-for-microvms.md
+++ b/docs/explanation/using-qemu-for-microvms.md
@@ -19,7 +19,7 @@ QEMU provides additional components that were added to support this special use 
 
 As an example, if you happen to already have a stripped-down workload that has all it would execute contained in an initrd, you might run it like this:
 
-```console
+```bash
 qemu-system-x86_64 \
  -M ubuntu-q35 \
  -cpu host \
@@ -39,7 +39,7 @@ To run the same basic command with `microvm` you would run it with with type `mi
 
 Our command then becomes:
 
-```console
+```bash
 qemu-system-x86_64 \
  -M microvm ubuntu-q35 \
  -cpu host \
@@ -57,7 +57,7 @@ qemu-system-x86_64 \
 
 To run the basic command with `qboot` instead, we would use the `qboot bios` by adding `-bios /usr/share/qemu/bios-microvm.bin`.
 
-```console
+```bash
 qemu-system-x86_64 \
  -M ubuntu-q35 \
  -cpu host \
@@ -82,7 +82,7 @@ sudo apt install qemu-system-x86-microvm
 
 Then, our basic command will look like this:
 
-```console
+```bash
 qemu-system-x86_64 \
  -M microvm \
  -bios /usr/share/qemu/bios-microvm.bin \

--- a/docs/how-to/how-to-enable-nested-virtualization.md
+++ b/docs/how-to/how-to-enable-nested-virtualization.md
@@ -10,7 +10,7 @@ There may be use cases where you need to enable nested virtualisation so that yo
 
 Check if the required kernel module for your CPU is already loaded. Hosts with Intel CPUs require the `kvm_intel` module while AMD hosts require `kvm_amd` instead:
   
-```console
+```bash
 $ lsmod | grep -i kvm
 kvm_intel               204800  0
 kvm                  1347584  1 kvm_intel
@@ -20,13 +20,13 @@ kvm                  1347584  1 kvm_intel
 
 If the module is already loaded, you can check if nested virtualisation is enabled by running the following command:
 
-```console
+```bash
 cat /sys/module/<module>/parameters/nested
 ```
 
 As an example for AMD hosts:
 
-```console
+```bash
 $ cat /sys/module/kvm_amd/parameters/nested
 1
 ```
@@ -37,13 +37,13 @@ If the output is either `1` or `Y` then nested virtualisation is enabled and you
 
 If the module your host requires is not loaded you can load it using `modprobe` and add the property `nested=1` to enable nested virtualisation as shown below for Intel hosts:
 
-```console
+```bash
 modprobe kvm-intel nested=1
 ```
 
 Or as follows for AMD hosts: 
 
-```console
+```bash
 modprobe kvm-amd nested=1
 ```
 
@@ -56,20 +56,20 @@ If the above checks indicate that nested virtualisation is not enabled, you can 
 
   * Reload the kernel module to apply the changes:
 
-  ```
+  ```bash
     sudo modprobe -r <module>
   ```
 
   Example for Intel hosts:
 
-  ```
+  ```bash
     sudo modprobe -r kvm-intel
   ```
 
   * You should now be able to see nested virtualisation enabled:
 
   Example for Intel hosts:
-  ```
+  ```bash
     $ cat /sys/module/kvm_intel/parameters/nested
     Y
   ```
@@ -80,7 +80,7 @@ Once the host is ready to use nested virtualisation it is time to check if the g
 
 To determine if an instance can host another instance on top, run the below command within the instance:
 
-```
+```bash
 egrep "svm|vmx" /proc/cpuinfo
 ``` 
 
@@ -91,7 +91,7 @@ If any of these are present in the output (depending on whether the host is AMD 
   * Search the `cpu mode` parameter in and set its value to either `host-model` or `host-passthrough` (details about these modes can be found [here](https://wiki.openstack.org/wiki/LibvirtXMLCPUModel)).
 
     Sample `cpu mode` parameter in XML with nested virtualisation: 
-    ```
+    ```xml
       <cpu mode='host-model' check='partial'/>
     ```
   * Save the modifications and start the instance

--- a/docs/how-to/libvirt.md
+++ b/docs/how-to/libvirt.md
@@ -4,7 +4,7 @@
 
 The [libvirt library](https://libvirt.org/) is used to interface with many different virtualisation technologies. Before getting started with libvirt it is best to make sure your hardware supports the necessary virtualisation extensions for [Kernel-based Virtual Machine (KVM)](https://www.linux-kvm.org/page/Main_Page). To check this, enter the following from a terminal prompt:
 
-```
+```bash
 kvm-ok
 ```
 
@@ -66,31 +66,31 @@ There are several utilities available to manage virtual machines and libvirt. Th
 
 - To list running virtual machines:
 
-  ```console
+  ```bash
   virsh list
   ```
 
 - To start a virtual machine:
 
-  ```console
+  ```bash
   virsh start <guestname>
   ```
 
 - Similarly, to start a virtual machine at boot:
 
-  ```console
+  ```bash
   virsh autostart <guestname>
   ```
 
 - Reboot a virtual machine with:
   
-  ```console
+  ```bash
   virsh reboot <guestname>
   ```
 
 - The **state** of virtual machines can be saved to a file in order to be restored later. The following will save the virtual machine state into a file named according to the date:
 
-  ```console
+  ```bash
   virsh save <guestname> save-my.state
   ```
 
@@ -98,25 +98,25 @@ There are several utilities available to manage virtual machines and libvirt. Th
 
 - A saved virtual machine can be restored using:
 
-  ```console
+  ```bash
   virsh restore save-my.state
   ```
 
 - To shut down a virtual machine you can do:
 
-  ```console
+  ```bash
   virsh shutdown <guestname>
   ```
 
 - A CD-ROM device can be mounted in a virtual machine by entering:
 
-  ```console
+  ```bash
   virsh attach-disk <guestname> /dev/cdrom /media/cdrom
   ```
 
 - To change the definition of a guest, `virsh` exposes the domain via:
 
-  ```console
+  ```bash
   virsh edit <guestname>
   ```
 
@@ -131,7 +131,7 @@ Editing the XML directly certainly is the most powerful way, but also the most c
 
 You can pass connection strings to `virsh` - as well as to most other tools for managing virtualisation.
 
-  ```console
+```bash
 virsh --connect qemu:///system
 ```
 
@@ -206,7 +206,7 @@ Virtual functions are usually assigned via their PCI ID (domain, bus, slot, func
 > **Note**:
 > To get the virtual function in the first place is very device dependent and can therefore not be fully covered here. But in general it involves setting up an IOMMU, registering via [VFIO](https://www.kernel.org/doc/Documentation/vfio.txt) and sometimes requesting a number of VFs. Here an example on ppc64el to get 4 VFs on a device:
 > 
-> ``` bash
+> ```bash
 > $ sudo modprobe vfio-pci
 > # identify device
 > $ lspci -n -s 0005:01:01.3
@@ -354,7 +354,7 @@ address sizes   : 39 bits physical, 48 bits virtual
 Since libvirt version 8.7.0 (>= Ubuntu 22.10 Lunar), `maxphysaddr` can be controlled via the [CPU model and topology section](https://libvirt.org/formatdomain.html#cpu-model-and-topology) of the guest configuration. 
 If one needs just a large guest, like before when using the `-hpb` types, all that is needed is the following libvirt guest xml configuration:
 
-```
+```xml
   <maxphysaddr mode='passthrough' />
 ```
 
@@ -362,13 +362,13 @@ Since libvirt 9.2.0 and 9.3.0 (>= Ubuntu 23.10 Mantic), an explicit number of em
 
 But now, one can either set a fix value of addressing bits:
 
-```
+```xml
   <maxphysaddr mode='emulate' bits='42'/>
 ```
 
 Or use the best available by a given hardware, without going over a certain limit to retain some compute node compatibility.
 
-```
+```xml
   <maxphysaddr mode='passthrough' limit='41/>
 ```
 

--- a/docs/how-to/virtual-machine-manager.md
+++ b/docs/how-to/virtual-machine-manager.md
@@ -7,19 +7,19 @@ The [Virtual Machine Manager](https://virt-manager.org/), through the `virt-mana
 
 To install `virt-manager`, enter:
 
-```console
+```bash
 sudo apt install virt-manager
 ```
 
 Since `virt-manager` requires a Graphical User Interface (GUI) environment we recommend installing it on a workstation or test machine instead of a production server. To connect to the local libvirt service, enter:
 
-```console
+```bash
 virt-manager
 ```
 
 You can connect to the libvirt service running on another host by entering the following in a terminal prompt:
 
-```console
+```bash
 virt-manager -c qemu+ssh://virtnode1.mydomain.com/system
 ```
 
@@ -62,13 +62,13 @@ The Virtual Machine Viewer application, through `virt-viewer`, allows you to con
 
 If `virt-viewer` is not already installed, you can install it from the terminal with the following command:
 
-```console
+```bash
 sudo apt install virt-viewer
 ```
 
 Once a virtual machine is installed and running you can connect to the virtual machine's console by using:
 
-```console
+```bash
 virt-viewer <guestname>
 ```
 
@@ -78,7 +78,7 @@ The UI will show a window representing the virtual screen of the guest, just lik
 
 Similarly to `virt-manager`, `virt-viewer` can also connect to a remote host using SSH with key authentication:
 
-```console
+```bash
 virt-viewer -c qemu+ssh://virtnode1.mydomain.com/system <guestname>
 ```
 
@@ -94,13 +94,13 @@ If configured to use a **bridged** network interface you can also set up SSH acc
 
 To install `virt-install`, if it is not installed already, run the following from a terminal prompt:
 
-```console
+```bash
 sudo apt install virtinst
 ```
 
 There are several options available when using `virt-install`. For example:
 
-```console
+```bash
 virt-install \
  --name web_devel \
  --ram 8192 \
@@ -135,7 +135,7 @@ After launching `virt-install` you can connect to the virtual machine's console 
 
 The `virt-clone` application can be used to copy one virtual machine to another. For example:
 
-```console
+```bash
 virt-clone --auto-clone --original focal
 ```
 


### PR DESCRIPTION
- Use "bash" instead of "console" when showing CLI commands.

- Explicitly set the formatting option (xml, bash, etc.) for code
  snippets that didn't have one.