### PR TITLE
Add notice about QEMU requiring the user to be part of the kvm group

### DIFF
--- a/docs/how-to/boot-arm64-virtual-machines-on-qemu.md
+++ b/docs/how-to/boot-arm64-virtual-machines-on-qemu.md
@@ -1,6 +1,8 @@
 (boot-arm64-virtual-machines-on-qemu)=
 # Boot ARM64 virtual machines on QEMU
 
+```{include} ../notices/qemu-user-group-notice.md```
+
 Ubuntu ARM64 images can run inside QEMU. You can either do this fully emulated (e.g. on an x86 host) or accelerated with KVM if you have an ARM64 host. This page describes how to do both.
 
 > **Note**: 

--- a/docs/how-to/create-qemu-vms-with-up-to-1024-vcpus.md
+++ b/docs/how-to/create-qemu-vms-with-up-to-1024-vcpus.md
@@ -1,6 +1,8 @@
 (create-qemu-vms-with-up-to-1024-vcpus)=
 # Create QEMU VMs with up to 1024 vCPUs
 
+```{include} ../notices/qemu-user-group-notice.md```
+
 For a long time, QEMU only supported launching virtual machines with 288 vCPUs or fewer. While this was acceptable a decade ago, nowadays it is more common to see processors with 300+ physical cores available. For this reason, QEMU has been modified to support virtual machines with up to 1024 vCPUs. The caveat is that the user has to provide a few specific (and not trivial to guess) command line options to enable such a feature, and that is the gap that this document aims to fill.
 
 ## Supported QEMU versions

--- a/docs/how-to/virtualisation-with-qemu.md
+++ b/docs/how-to/virtualisation-with-qemu.md
@@ -1,6 +1,7 @@
 (virtualisation-with-qemu)=
 # Virtualisation with QEMU
 
+```{include} ../notices/qemu-user-group-notice.md```
 
 [QEMU](http://wiki.qemu.org/Main_Page) is a machine emulator that can run operating systems and programs for one machine on a different machine. However, it is more often used as a virtualiser in collaboration with [KVM](https://www.linux-kvm.org/page/Main_Page) kernel components. In that case it uses the hardware virtualisation technology to virtualise guests.
 

--- a/docs/notices/qemu-user-group-notice.md
+++ b/docs/notices/qemu-user-group-notice.md
@@ -1,0 +1,3 @@
+:::{note}
+Please bear in mind that invoking QEMU manually may sometimes require your user to be part of the `kvm` group.
+:::


### PR DESCRIPTION
This was discussed with @cpaelzer.  QEMU sometimes requires the user to be part of the `kvm` group in order to run commands, so we should display a notice to the reader whenever there's a QEMU command in a page.