### PR TITLE
Add backups section to MySQL docs

### DIFF
--- a/docs/how-to/install-and-configure-a-mysql-server.md
+++ b/docs/how-to/install-and-configure-a-mysql-server.md
@@ -101,11 +101,17 @@ It also lacks journaling, which makes it harder for data to be recovered after a
 
 ## Backups
 
-MySQL databases should be backed up regularly. Backups can be accomplished through several methods.
+MySQL databases should be backed up regularly. Backups can be accomplished through several methods, of which we'll discuss three here.
+
+[mysqldump](#mysqldump) is included with `mysql-server`. It is useful for backing up smaller databases, allows backups to be edited prior to a restore, and can be used for exporting to CSV and XML.
+
+[MySQL Shell's Dump Utility](#mysql-shell-dump-utility) allows for backups of specific schema and tables, both to local files and remote secure servers. It is recommended for creating partial backups, and for integration with Python programs.
+
+[Percona Xtrabackup](#percona-xtrabackup) creates full backups with far greater performance than the former options. However, it lacks the ability to customize schema and tables. It is the recommended option for backing up large databases in a production environment.
 
 ### mysqldump
 
-mysqldump is a built-in tool that performs [logical backups](https://dev.mysql.com/doc/refman/8.4/en/glossary.html#glos_logical_backup) for MySQL. It is useful for backing up smaller databases, allows backups to be edited prior to a restore, and can be used for exporting to csv and XML.
+`mysqldump` is a built-in tool that performs [logical backups](https://dev.mysql.com/doc/refman/8.4/en/glossary.html#glos_logical_backup) for MySQL.
 
 To dump the data of a publicly available database on the local MySQL server into a file, run the following:
 
@@ -129,7 +135,7 @@ See the [upstream documentation](https://dev.mysql.com/doc/refman/8.4/en/mysqldu
 
 ### MySQL Shell Dump Utility
 
-MySQL Shell, supported in Ubuntu 24.04 LTS and later, contains a set of utilities for dumping, backing up, and restoring MySQL data. It provides a programmatic option for logical backups with filtering options. This method is recommended for smaller backups to remote locations.
+MySQL Shell, supported in Ubuntu 24.04 LTS and later, contains a set of utilities for dumping, backing up, and restoring MySQL data. It provides a programmatic option for logical backups with filtering options.
 
 To install MySQL Shell, run the following:
 
@@ -161,13 +167,13 @@ util.load_dump("/tmp/worlddump")
 ```
 
 > **Note**:
-> To restore data from a local file, `local_infile` needs to be enabled on the MySQL server. Activate this by accessing the server with the `mysql` command and entering `SET GLOBAL local_infile=1;`
+> To restore data from a local file, `local_infile` needs to be enabled on the MySQL server. Activate this by accessing the server with the `mysql` command and entering `SET GLOBAL local_infile=1;`.
 
 See the [MySQL Shell dump documentation](https://dev.mysql.com/doc/mysql-shell/8.4/en/mysql-shell-utilities-dump-instance-schema.html) for more information.
 
 ### Percona Xtrabackup
 
-Also supported in Ubuntu 24.04 LTS and later, Percona Xtrabackup is a tool for creating [physical backups](https://dev.mysql.com/doc/refman/8.4/en/glossary.html#glos_physical_backup). It is similar to the commercial offering of [MySQL Enterprise Backup](https://www.mysql.com/products/enterprise/backup.html). Of the three solutions provided here, this is recommended for backing up MySQL databases in a scalable manner.
+Also supported in Ubuntu 24.04 LTS and later, Percona Xtrabackup is a tool for creating [physical backups](https://dev.mysql.com/doc/refman/8.4/en/glossary.html#glos_physical_backup). It is similar to the commercial offering of [MySQL Enterprise Backup](https://www.mysql.com/products/enterprise/backup.html).
 
 To install Xtrabackup, run the following command from a terminal prompt:
 


### PR DESCRIPTION
Add info on backups to MySQL server page to match Postgresql. Includes mysqldump, MySQL shell, and xtrabackup.