### PR TITLE
Avoid VPN and DHCP address space collision

### DIFF
--- a/how-to/wireguard-vpn/on-an-internal-system.md
+++ b/how-to/wireguard-vpn/on-an-internal-system.md
@@ -38,7 +38,7 @@ For example, in the case of the `10.10.10.0/24` network, the DHCP server on the 
 | Network | `10.10.10.0/24` |
 | Usable addresses | `10.10.10.2` -- `10.10.10.254` (`.1` is the router) |
 | DHCP range | `10.10.10.50` -- `10.10.10.254` |
-| VPN range | `10.10.10.10` -- `10.10.10.59` |
+| VPN range | `10.10.10.10` -- `10.10.10.49` |
 |||
 
 Or via any other layout that is better suited for your case. In this way, the router will never hand out a DHCP address that conflicts with one that we selected for a VPN user.


### PR DESCRIPTION
The address spaces for DHCP (10.10.10.50 – 10.10.10.254) and VPN (10.10.10.10 – 10.10.10.59) overlap from 10.10.10.50-10.10.10.59. Fairly sure these are supposed to be distinct spaces. There are two obvious ways to eliminate the overlap.

    DHCP 10.10.10.50 --> 10.10.10.60
or
    VPN 10.10.10.10.59 --> 10.10.10.49.

I have, rather arbitrarily, chosen the latter.