### PR TITLE
virtiofsd: avoid option not always present

### DIFF
--- a/how-to/virtualisation/libvirt.md
+++ b/how-to/virtualisation/libvirt.md
@@ -430,13 +430,7 @@ And in the guest this can now be used based on the tag `myfs` like:
 sudo mount -t virtiofs myfs /mnt/
 ```
 
-Compared to other Host/Guest file sharing options -- commonly Samba, NFS or 9P -- `virtiofs` is usually much faster and also more compatible with usual file system semantics. For some extra compatibility in regard to filesystem semantics one can add:
-
-```xml
-<binary xattr='on'>
-  <lock posix='on' flock='on'/>
-</binary>
-```
+Compared to other Host/Guest file sharing options -- commonly Samba, NFS or 9P -- `virtiofs` is usually much faster and also more compatible with usual file system semantics.
 
 See the [libvirt domain/filesytem](https://libvirt.org/formatdomain.html#filesystems) documentation for further details on these.
 


### PR DESCRIPTION
The virtiofsd server changed a lot in recent years, the version in Noble is no more having the flock option. I considered doing a huge "if release then" but the benefit is minimal. We already link to upstreams collection of examples which has this and many more which all work depending on your needs and versions.

Let us just take away the flock hint to avoid users of the more modern stack that does it well right away to be blocked by an error about non existing options.