### PR TITLE
ssh: fix service reference

### DIFF
--- a/how-to/security/openssh-server.md
+++ b/how-to/security/openssh-server.md
@@ -53,7 +53,7 @@ Banner /etc/issue.net
 After making changes to the `/etc/ssh/sshd_config` file, save the file. Then, restart the `sshd` server application to effect the changes using the following command:
 
 ```bash
-sudo systemctl restart sshd.service
+sudo systemctl restart ssh.service
 ```
 
 > **Warning**:

--- a/how-to/security/user-management.md
+++ b/how-to/security/user-management.md
@@ -246,7 +246,7 @@ Then add your permitted SSH users to the group `sshlogin`, and restart the SSH s
 
 ```bash
 sudo adduser username sshlogin
-sudo systemctl restart sshd.service
+sudo systemctl restart ssh.service
 ```
 
 ### External user database authentication


### PR DESCRIPTION
The old used to work and will work again after [1] is fixed, but the ssh service on disk is /usr/lib/systemd/system/ssh.service and sshd only an alias (which currently happens to be broken on noble). Using ssh.service in our examples avoids readers to stumble until fixed in an SRU and can stay as-is afterwards.

[1]: https://bugs.launchpad.net/ubuntu/+source/openssh/+bug/2087949

Fixes: #93