### PR TITLE
Add security intro

### DIFF
--- a/explanation/intro-to/security.md
+++ b/explanation/intro-to/security.md
@@ -2,168 +2,78 @@
 # Introduction to security
 
 Security should always be considered when installing, deploying, and using any
-type of computer system. Although a fresh installation of Ubuntu is relatively
-safe for immediate use on the Internet, it is important to have a balanced
-understanding of your system's security posture based on how it will be used
-after deployment.
+Ubuntu system. Although a fresh installation of Ubuntu is relatively safe for
+immediate use, it is important to have a balanced understanding of your
+system's security posture based on how it will be used after deployment. It's
+important to take a layered approach so that your system's security is not
+dependent on a single 
 
-## General guidance for all systems
+## Server security guidance
 
-It is generally good practice to take a proactive and layered approach to
-security. These suggestions are good practices for any Ubuntu system.
+Since Ubuntu is so endlessly customizable, a full guide to security hardening
+is beyond the scope of this documentation.
+However, there are good practices and security-related packages that could be
+applied to almost any Ubuntu system. See our
+{ref}`security suggestions <security-suggestions>` page for an overview of the
+good habits and practices that can be adopted by anyone running an Ubuntu
+system to make it more secure. It's not necessary to apply every suggestion --
+and the list is not exhaustive by any means -- but each one used creates an
+extra layer of security.
 
-## Keep your system up-to-date
+In a more advanced or complex setup, you may need to go further in your
+security outlook. There are specific packages available for your Server
+that will help with this, and we suggest some in the
+{ref}`advanced security <advanced-security>` section that you might want to
+consider for your use-case. Again, the list is not intended to be exhaustive,
+but rather a starting point.
 
-1. **Regularly update** your Ubuntu Server to keep it protected from known
-   vulnerabilities:
-
-   ```bash
-   sudo apt update && sudo apt upgrade
-   ```
-
-1. **Use the `unattended-upgrade` package** to automatically fetch and install
-   security updates and bug fixes:
-
-   ```
-   sudo apt install unattended-upgrades
-   ```
-
-   By default, `unattended-upgrade` runs daily, but this can be configured. See
-   the `unattended-upgrade`
-   [manual page](https://manpages.ubuntu.com/manpages/noble/en/man8/unattended-upgrades.8.html)
-   for details.
-
-1. **Use Ubuntu Pro**. If you are on an older Ubuntu release and don't want to
-   upgrade just yet, Ubuntu Pro provides
-   [10 years of security coverage](https://ubuntu.com/security/esm) for all
-   packages in the Main and Universe repositories. It is free for personal or
-   business use on up to 5 machines.
-
-1. **Remove packages you don't need**, to minimise the
-   potential attack surface. See our article on
-   {ref}`Package management <package-management>` for more details.
-
-1. It's also a good idea to **use the most up-to-date release** of Ubuntu
-   Server. We have instructions on
-   {ref}`how to upgrade your release <upgrade-your-release>`.
-
-## Access Control
-
-1. **Use and enforce** the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege):
-
-   * This means creating non-root user accounts with as few privileges as possible
-   * Not using `sudo` (root access) except for administration tasks
-   * For more details on basic access control, see our {ref}`guide on user management <user-management>` 
-
-1. Use the **Secure Shell (SSH)** protocol to secure remote access. In Ubuntu,
-   this is managed through the OpenSSH software. For details on setting up
-   OpenSSH, refer to our {ref}`guide to OpenSSH <openssh-server>`.
-
-1. For larger or more complex setups, access control is usually gated through
-   tools such as OpenLDAP. Refer to our
-   {ref}`introduction to OpenLDAP <introduction-to-openldap>`
-   for more details, or see our section
-   {ref}`on how to set up OpenLDAP <how-to-openldap>`.
-
-## Network security
-
-1. **Use a firewall**. ufw {ref}`firewalls`
-
-<!--- * Close unused ports: scan
- do we have anything about ports? --->
-
-<!--- Does Network security fall under encryptying data in transit? --->
-
-<!--- Do we need to include our networking content on DNSSEC?
-* {ref}`install-dnssec`
---->
-
-<!--- For network authentication/authorisation/user and groups from a variety of network sources, we also have SSSD --->
-
-## Data Protection:
-
-* At rest:
-
-  Tools like LUKS for full-disk encryption <!--- currently only have any mention of LUKS in the subiquity docs --->
-  Physical security: Smart card authentication (+ with SSH - overlaps with SSH)
-  <!-- missing content about yubikeys -->
-  Console security
-  <!-- Do we need anything backup policies or disaster recovery plans? redundancy? -->
-
-* In transit
-
-  TLS/SSL for secure communication <!--- We don't have pages on TLS or SSL individually, but we do have:
-  
-  * {ref}`LDAP and TLS <ldap-and-tls>`
-  * {ref}`Troubleshooting TLS/SSL <>`
-    --->
-
-Link to - do we have specific pages about this?
-- nothing about luks, only referenced in the subiquity pages
-- TLS - we have LDAP and TLS, troubleshooting TLS/SSL, GnuTLS
-* :ref:``
-
-## Monitoring and Logging:
-
-* Actively monitor server activity and maintain logs using tools like journalctl or centralized logging frameworks. - nothing in logging about this
-* Detect and block suspicious behavior with tools like Fail2ban.
-
-detect and block/fail2ban - missing
-journalctl - nothing specifically about this
-
-
-These foundational practices are crucial for any Ubuntu Server deployment, ensuring that the server is resistant to common attack vectors.
+For a more thorough treatment of security in Ubuntu, we recommend checking
+out the [Ubuntu Security documentation](https://ubuntu.com/security).
 
 ## Ubuntu Pro
 
+Canonical offers security, compliance and support services through the
+[Ubuntu Pro](https://ubuntu.com/pro) subscription. Ubuntu Pro is available
+for free on up to 5 machines (for business or personal use). Although the
+compliance and certification features of Ubuntu Pro are likely to be of more
+interest to enterprise users, the security patching features are great for
+anyone using Ubuntu.
 
-<!--- We need a trampoline to CVEs/USNs and the disclosure policy --->
+All of the Ubuntu Pro features can be managed on the command line via the
+[Ubuntu Pro Client](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/)
+utility, which also has an API for easier automation.
 
+### Vulnerability management
 
-* Information about known vulnerabilities:
-  * per CVE check out the [CVE overview](https://ubuntu.com/security/cves)
-  * per Package have a look at the [Ubuntu Security Notices](https://ubuntu.com/security/notices)
-* Reporting a security issue, have a look at the [disclosure policy](https://ubuntu.com/security/disclosure-policy)
+In a standard Ubuntu LTS release, security support is provided for packages in
+the Main repository for 5 years. With Ubuntu Pro, this is expanded to 10 years,
+and also includes patching for medium, high and critival severity
+[vulnerabilities](https://ubuntu.com/security/cves/about) for the Universe
+repository.
 
-### Kernel application hardening:
+This service, known as Expanded Security Maintenance (ESM), is recommended for
+every Ubuntu system. Learn more [about ESM](https://ubuntu.com/security/esm).
 
-* [Canonical Livepatch](https://ubuntu.com/security/livepatch) applies kernel
-  patches for high and critical severity vulnerabilities, while the system is
-  running, and without the need for an immediate reboot.
-  
-### ESM
+### Kernel application hardening
 
+The second service recommended for every Ubuntu system is Canonical's Livepatch
+service, which applies kernel patches for high and critical severity
+vulnerabilities while the system is running, and without the need for an
+immediate reboot -- reducing downtime. Learn more
+[about Livepatch](https://ubuntu.com/security/livepatch).
 
+### Security Compliance and Certification
 
-# Advanced topics
+For enterprise users who must ensure compliance with specific standards, such as
+[FIPS](https://ubuntu.com/security/certifications/docs/fips),
+[CIS](https://ubuntu.com/security/certifications/docs/usg) and
+[DISA STIG](https://ubuntu.com/security/certifications/docs/disa-stig), Ubuntu
+also provides profile benchmarking. See our
+[security and compliance documentation](https://ubuntu.com/security/certifications/docs)
+for more details.
+ 
+## Reporting vulnerabilities
 
-## Centralised access and identity management
-
-* Lightweight Directory Access Protocol (LDAP)
-* Kerberos
-
-## VPNs and network segmentation
-
-* WireGuard VPN
-
-<!--- we don't have anything specifically called out about network segmentation - is it really that important? --->
-
-## Mandatory Access Controls (MAC)
-
-* AppArmor
-
-## Cryptography / cryptographic libraries
-
-* intro to crypto libraries {ref}`crypto-libraries`
-
-## Compliance and auditing:
-
-If you need to adhere to specific industry standards, refer to the Ubuntu
-Security Guide.
-
-* FIPS
-* CIS/USG
-
-<!--- FOR YANA: what do we have in the security docs that we should link to on this topic? --->
-<!--- it's beyond the scope of the server docs to document the different compliance stuff, but we should have a single page trampoline that introduces the concept and provides links --->
+If you need to report a security issue, refer to the security
+[disclosure policy](https://ubuntu.com/security/disclosure-policy).
 

--- a/explanation/intro-to/security.md
+++ b/explanation/intro-to/security.md
@@ -6,7 +6,7 @@ Ubuntu system. Although a fresh installation of Ubuntu is relatively safe for
 immediate use, it is important to have a balanced understanding of your
 system's security posture based on how it will be used after deployment. It's
 important to take a layered approach so that your system's security is not
-dependent on a single 
+dependent on a single point of defense.
 
 ## Server security guidance
 
@@ -27,7 +27,7 @@ that will help with this, and we suggest some in the
 consider for your use-case. Again, the list is not intended to be exhaustive,
 but rather a starting point.
 
-For a more thorough treatment of security in Ubuntu, we recommend checking
+For a more thorough treatment of security in Ubuntu, we also recommend checking
 out the [Ubuntu Security documentation](https://ubuntu.com/security).
 
 ## Ubuntu Pro
@@ -36,7 +36,7 @@ Canonical offers security, compliance and support services through the
 [Ubuntu Pro](https://ubuntu.com/pro) subscription. Ubuntu Pro is available
 for free on up to 5 machines (for business or personal use). Although the
 compliance and certification features of Ubuntu Pro are likely to be of more
-interest to enterprise users, the security patching features are great for
+interest to enterprise users, the enhanced security coverage is great for
 anyone using Ubuntu.
 
 All of the Ubuntu Pro features can be managed on the command line via the
@@ -46,8 +46,9 @@ utility, which also has an API for easier automation.
 ### Vulnerability management
 
 In a standard Ubuntu LTS release, security support is provided for packages in
-the Main repository for 5 years. With Ubuntu Pro, this is expanded to 10 years,
-and also includes patching for medium, high and critival severity
+the [Main repository](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/explanation/archive/#components)
+for 5 years. With Ubuntu Pro, this is expanded to 10 years, and also includes
+patching for medium, high and critival severity
 [vulnerabilities](https://ubuntu.com/security/cves/about) for the Universe
 repository.
 

--- a/explanation/intro-to/security.md
+++ b/explanation/intro-to/security.md
@@ -1,14 +1,169 @@
 (introduction-to-security)=
 # Introduction to security
 
-Security should always be considered when installing, deploying, and using any type of computer system. Although a fresh installation of Ubuntu is relatively safe for immediate use on the Internet, it is important to have a balanced understanding of your system's security posture based on how it will be used after deployment.
+Security should always be considered when installing, deploying, and using any
+type of computer system. Although a fresh installation of Ubuntu is relatively
+safe for immediate use on the Internet, it is important to have a balanced
+understanding of your system's security posture based on how it will be used
+after deployment.
 
-This chapter provides an overview of security-related topics as they pertain to Ubuntu Server Edition, and outlines simple measures you may use to protect your server and network from any number of potential security threats.
+## General guidance for all systems
 
-## About security at Ubuntu
+It is generally good practice to take a proactive and layered approach to
+security. These suggestions are good practices for any Ubuntu system.
 
-* Further information about security at Ubuntu, have a look at [Ubuntu Security](https://ubuntu.com/security)
+## Keep your system up-to-date
+
+1. **Regularly update** your Ubuntu Server to keep it protected from known
+   vulnerabilities:
+
+   ```bash
+   sudo apt update && sudo apt upgrade
+   ```
+
+1. **Use the `unattended-upgrade` package** to automatically fetch and install
+   security updates and bug fixes:
+
+   ```
+   sudo apt install unattended-upgrades
+   ```
+
+   By default, `unattended-upgrade` runs daily, but this can be configured. See
+   the `unattended-upgrade`
+   [manual page](https://manpages.ubuntu.com/manpages/noble/en/man8/unattended-upgrades.8.html)
+   for details.
+
+1. **Use Ubuntu Pro**. If you are on an older Ubuntu release and don't want to
+   upgrade just yet, Ubuntu Pro provides
+   [10 years of security coverage](https://ubuntu.com/security/esm) for all
+   packages in the Main and Universe repositories. It is free for personal or
+   business use on up to 5 machines.
+
+1. **Remove packages you don't need**, to minimise the
+   potential attack surface. See our article on
+   {ref}`Package management <package-management>` for more details.
+
+1. It's also a good idea to **use the most up-to-date release** of Ubuntu
+   Server. We have instructions on
+   {ref}`how to upgrade your release <upgrade-your-release>`.
+
+## Access Control
+
+1. **Use and enforce** the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege):
+
+   * This means creating non-root user accounts with as few privileges as possible
+   * Not using `sudo` (root access) except for administration tasks
+   * For more details on basic access control, see our {ref}`guide on user management <user-management>` 
+
+1. Use the **Secure Shell (SSH)** protocol to secure remote access. In Ubuntu,
+   this is managed through the OpenSSH software. For details on setting up
+   OpenSSH, refer to our {ref}`guide to OpenSSH <openssh-server>`.
+
+1. For larger or more complex setups, access control is usually gated through
+   tools such as OpenLDAP. Refer to our
+   {ref}`introduction to OpenLDAP <introduction-to-openldap>`
+   for more details, or see our section
+   {ref}`on how to set up OpenLDAP <how-to-openldap>`.
+
+## Network security
+
+1. **Use a firewall**. ufw {ref}`firewalls`
+
+<!--- * Close unused ports: scan
+ do we have anything about ports? --->
+
+<!--- Does Network security fall under encryptying data in transit? --->
+
+<!--- Do we need to include our networking content on DNSSEC?
+* {ref}`install-dnssec`
+--->
+
+<!--- For network authentication/authorisation/user and groups from a variety of network sources, we also have SSSD --->
+
+## Data Protection:
+
+* At rest:
+
+  Tools like LUKS for full-disk encryption <!--- currently only have any mention of LUKS in the subiquity docs --->
+  Physical security: Smart card authentication (+ with SSH - overlaps with SSH)
+  <!-- missing content about yubikeys -->
+  Console security
+  <!-- Do we need anything backup policies or disaster recovery plans? redundancy? -->
+
+* In transit
+
+  TLS/SSL for secure communication <!--- We don't have pages on TLS or SSL individually, but we do have:
+  
+  * {ref}`LDAP and TLS <ldap-and-tls>`
+  * {ref}`Troubleshooting TLS/SSL <>`
+    --->
+
+Link to - do we have specific pages about this?
+- nothing about luks, only referenced in the subiquity pages
+- TLS - we have LDAP and TLS, troubleshooting TLS/SSL, GnuTLS
+* :ref:``
+
+## Monitoring and Logging:
+
+* Actively monitor server activity and maintain logs using tools like journalctl or centralized logging frameworks. - nothing in logging about this
+* Detect and block suspicious behavior with tools like Fail2ban.
+
+detect and block/fail2ban - missing
+journalctl - nothing specifically about this
+
+
+These foundational practices are crucial for any Ubuntu Server deployment, ensuring that the server is resistant to common attack vectors.
+
+## Ubuntu Pro
+
+
+<!--- We need a trampoline to CVEs/USNs and the disclosure policy --->
+
+
 * Information about known vulnerabilities:
   * per CVE check out the [CVE overview](https://ubuntu.com/security/cves)
   * per Package have a look at the [Ubuntu Security Notices](https://ubuntu.com/security/notices)
 * Reporting a security issue, have a look at the [disclosure policy](https://ubuntu.com/security/disclosure-policy)
+
+### Kernel application hardening:
+
+* [Canonical Livepatch](https://ubuntu.com/security/livepatch) applies kernel
+  patches for high and critical severity vulnerabilities, while the system is
+  running, and without the need for an immediate reboot.
+  
+### ESM
+
+
+
+# Advanced topics
+
+## Centralised access and identity management
+
+* Lightweight Directory Access Protocol (LDAP)
+* Kerberos
+
+## VPNs and network segmentation
+
+* WireGuard VPN
+
+<!--- we don't have anything specifically called out about network segmentation - is it really that important? --->
+
+## Mandatory Access Controls (MAC)
+
+* AppArmor
+
+## Cryptography / cryptographic libraries
+
+* intro to crypto libraries {ref}`crypto-libraries`
+
+## Compliance and auditing:
+
+If you need to adhere to specific industry standards, refer to the Ubuntu
+Security Guide.
+
+* FIPS
+* CIS/USG
+
+<!--- FOR YANA: what do we have in the security docs that we should link to on this topic? --->
+<!--- it's beyond the scope of the server docs to document the different compliance stuff, but we should have a single page trampoline that introduces the concept and provides links --->
+

--- a/explanation/security.rst
+++ b/explanation/security.rst
@@ -3,6 +3,7 @@
 Security
 *********
 
+* :ref:`security-suggestions`
 * :ref:`OpenVPN clients <openvpn-client-implementations>`
 * :ref:`Certificates <certificates>`
 * :ref:`DNSSEC <dnssec>`
@@ -10,6 +11,7 @@ Security
 .. toctree::
     :hidden:
 
+    security/security_suggestions
     OpenVPN clients <security/openvpn-client-implementations>
     Certificates <security/certificates>
     DNSSEC <dnssec/dnssec>

--- a/explanation/security/security_suggestions.md
+++ b/explanation/security/security_suggestions.md
@@ -122,49 +122,60 @@ documentation.
    {ref}`introduction to SSSD <introduction-to-network-user-authentication-with-sssd>`
    or get started setting it up with our
    {ref}`how-to section <how-to-network-user-authentication-with-sssd>`.
-
-### Virtual Private Networks (VPNs)
-
-1. **WireGuard VPN**
-
-   * {ref}`Introduction to WireGuard VPN <introduction-to-wireguard-vpn>`
-   * {ref}`How to set up WireGuard VPN <how-to-wireguard-vpn>`
-
-1. **OpenVPN**
-   
-   * {ref}`About OpenVPN clients <openvpn-client-implementations>`
-   * {ref}`How to install OpenVPN <install-openvpn>`
+1. **Active Directory**, the directory service for Windows domain networks, can
+   be set up to allow your Ubuntu Server to integrate with a Windows network.
+   Find out more about
+   {ref}`Active Directory integration <explanation-active-directory-integration>`,
+   or {ref}`learn how to set it up <how-to-active-directory-integration>`.
+   You may also find ADSys, the Group Policy client for Ubuntu, helpful. See
+   the [ADSys documentation](https://documentation.ubuntu.com/adsys/en/latest/)
+   for more details.
+1. **AppArmor** is strongly recommended in order to limit the system access and
+   capabilities of the software running on your systems. It enforces Mandatory
+   Access Control (MAC) policies for individual applications to ensure that
+   even if an application is compromised, the amount of damage caused is
+   limited. We have a how-to guide that will show you
+   {ref}`how to set up AppArmor <apparmor>`.
 
 ### Security of communications
 
-1. **TLS/SSL** for secure communication
+VPNs are an important tool for system administrators. They provide encrypted,
+secure connections between a network and the users connecting to it. Two of the
+most popular choices in Ubuntu are **WireGuard VPN** and **OpenVPN**.
 
-<!--- We don't have specific pages on TLS or SSL individually, but we do have:
-We don't have pages on TLS or SSL individually, but we do have:
-How-to: LDAP: {ref}`LDAP and TLS <ldap-and-tls>` (this is the closest we have to a discussion of the topic, and it’s within the how-to LDAP section)
-Explanation: Cryptography: {ref}`GnuTLS <gnutls>`
-Explanation: Cryptography: {ref}`OpenSSL <openssl>`
-Explanation: Cryptography: {ref}`Troubleshooting TLS/SSL <troubleshooting-tls>`
-Explanation: security: {ref}`OpenVPN <openvpn-client-implementations>` which is a VPN in the SSL/TLS VPN stack (as opposed to an IPSec VPN)
---->
+1. **WireGuard VPN** is a modern and performant option, and it removes much of
+   the complexity from the configuration and deployment of a VPN. To get an
+   overview, see our
+   {ref}`Introduction to WireGuard VPN <introduction-to-wireguard-vpn>`. You
+   can then find out how to {ref}`set up WireGuard VPN <how-to-wireguard-vpn>`.
 
-### Mandatory Access Controls (MAC)
+1. **OpenVPN** is a well-established and widely supported option with a large
+   user base. It supports many platforms besides Linux, including Windows,
+   macOS and iOS. Find out more
+   {ref}`about the available clients <openvpn-client-implementations>`, or see
+   our guide on {ref}`how to install OpenVPN <install-openvpn>`.
 
-1. **AppArmor**
-   
-   * {ref}`How to set up AppArmor <apparmor>`
+It's also important to consider **Transport Layer Security (TLS)** and/or
+**Secure Sockets Layer (SSL)** for securely encrypting data in transit. These
+cryptographic protocols provide privacy, integrity and authenticity to the
+communications being passed between two clients, or between a client and server.
+The exact implementation you choose will depend upon your setup, and there are
+many options available.
 
-### Cryptography / cryptographic libraries
+### Cryptography
 
-1. **Crypto libraries**
+There are many **cryptographic libraries** available in Ubuntu. For an overview
+of the most common ones, including some more details about TLS and SSL, refer
+to our page {ref}`about crypto libraries <explanation-cryptography>`. For a
+more high level overview of cryptographic libraries in general, see our
+{ref}`introduction-to-crypto-libraries`
 
-   * {ref}`introduction-to-crypto-libraries`
-   * {ref}`About crypto libraries <explanation-cryptography>`
-
-1. **Certificates**
-
-   * {ref}`About certificates <certificates>`
-   * {ref}`Install root CA certificate in the trust store <install-a-root-ca-certificate-in-the-trust-store>`
+Of course, no discussion of cryptography would be complete without including
+**certificates**. For more details about what certificates are and how they are
+used, see our {ref}`About certificates <certificates>` page. Alternatively,
+if you are familiar with the concepts of certificates and Certification
+Authorities (CA), our how-to guide will show you how to
+{ref}`Install root CA certificate in the trust store <install-a-root-ca-certificate-in-the-trust-store>`
 
 ### Compliance and auditing
 

--- a/explanation/security/security_suggestions.md
+++ b/explanation/security/security_suggestions.md
@@ -1,0 +1,177 @@
+(security-suggestions)=
+# Security suggestions
+
+Although a fresh install of Ubuntu is relatively safe for immediate use on the
+Internet, in this guide we’ll take a look at some steps you can take to help
+keep your Ubuntu system safe and secure.
+
+## For any Ubuntu system
+
+The following suggestions are applicable generally to most Ubuntu systems. It
+is not necessary to use all of these steps -- use the ones that are most
+relevant for your setup.
+
+### Keep your system up-to-date
+
+1. **Regularly update** your Ubuntu system to keep it protected from known
+   vulnerabilities. Run the following command periodically to update your
+   system software:
+
+   ```bash
+   sudo apt update && sudo apt upgrade
+   ```
+
+   You may want to use the `unattended-upgrade` package to fetch and install
+   security updates and bug fixes automatically:
+
+   ```
+   sudo apt install unattended-upgrades
+   ```
+
+   By default, `unattended-upgrade` runs daily, but this can be configured. See
+   the `unattended-upgrade`
+   [manual page](https://manpages.ubuntu.com/manpages/noble/en/man8/unattended-upgrades.8.html)
+   for details.
+
+1. **Manage your software**:
+
+   * Remove packages you don't need, to minimise the potential attack surface
+     you are exposing. See our article on
+     {ref}`Package management <package-management>` for more details.
+
+   * Avoid using third party repositories. If you need to download a package
+     from a third party repository, make sure you
+     {ref}`understand the risks and how to minimize them. <third-party-repository-usage>`.
+
+1. **Use the most up-to-date release** of Ubuntu. If you are on an older Ubuntu
+   release we have instructions on {ref}`how to upgrade <upgrade-your-release>`.
+ 
+1. **Use [Ubuntu Pro](https://ubuntu.com/pro)**, particularly if you are on an
+   older release of Ubuntu. Pro provides Enterprise-level security patching,
+   but is free for personal/business use on up to 5 machines. The most useful
+   Pro features for *any* Ubuntu Server are:
+
+   * [Expanded Security Maintenance (ESM)](https://ubuntu.com/security/esm)
+     which expands the Ubuntu LTS commitment on packages in Main from 5 years
+     to 10 years -- and now also covers packages in Ubuntu Universe.
+   
+   * [Livepatch](https://ubuntu.com/security/livepatch) applies kernel patches
+     for high and critical severity vulnerabilities while the system is running.
+     This avoids the need for an immediate reboot.
+
+   Most security patches can be fetched and applied automatically through the
+   `unattended-upgrade` package. For more details on using and monitoring
+   Ubuntu Pro via the command line, refer to the
+   [official documentation](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/).
+
+### Access Control
+
+1. **Use and enforce** the
+   [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege):
+
+   * This means creating non-root user accounts with as few privileges as possible.
+   * Not using `sudo` (root access) except for administration tasks.
+   * For more details on basic access control, see our {ref}`guide on user management <user-management>`.
+
+### Network security
+
+1. **Use a firewall**. In Ubuntu, the uncomplicated firewall (`ufw`) tool is
+   used to configure firewalls. `ufw` is a wrapper around the `iptables` utility
+   (which experienced system admins may prefer to use directly). To get started
+   with `ufw`, check out our {ref}`firewalls` guide.
+
+1. **Use the Secure Shell (SSH)** protocol to secure remote access. In Ubuntu,
+   this is managed through OpenSSH. For details on setting up OpenSSH, refer to
+   our {ref}`guide to OpenSSH <openssh-server>`. 
+
+### Physical security
+
+There are also steps you can take to protect the physical security of your
+system. These how-to guides will help you set up these additional precautions:
+
+* {ref}`Smart card authentication <smart-card-authentication>`.
+* {ref}`Smart card authentication with SSH <smart-card-authentication-with-ssh>`.
+* {ref}`Console security <console-security>`.
+
+
+(advanced-security)=
+## Suggestions for complex setups
+
+The following section will help direct you to the security-related packages for
+which we provide documentation. For more discussion about advanced security
+considerations, refer to the [Ubuntu Security](https://ubuntu.com/security)
+documentation. 
+
+### Advanced Access Control
+
+1. **Lightweight Directory Access Protocol (LDAP)** is the usual way to gate
+   access control for larger or more complex setups. In Ubuntu, this is
+   implemented through OpenLDAP. Refer to our
+   {ref}`introduction to OpenLDAP <introduction-to-openldap>`
+   for more details, or see our section
+   {ref}`on how to set up OpenLDAP <how-to-openldap>`.
+1. **Kerberos** is a network authentication protocol that provides identity
+   verification for distributed environments, commonly used in enterprise
+   systems. Learn more in our
+   {ref}`introduction to Kerberos <introduction-to-kerberos>`, or see our
+   section on how to {ref}`set up and use Kerberos <how-to-kerberos>`.
+1. **System Security Services Daemon (SSSD)** is a collection of daemons that
+   handle authentication, authorisation and user/group information from
+   disparate network sources. It integrates with OpenLDAP, Kerberos, and
+   Active Directory as we discuss in more detail in our
+   {ref}`introduction to SSSD <introduction-to-network-user-authentication-with-sssd>`
+   or get started setting it up with our
+   {ref}`how-to section <how-to-network-user-authentication-with-sssd>`.
+
+### Virtual Private Networks (VPNs)
+
+1. **WireGuard VPN**
+
+   * {ref}`Introduction to WireGuard VPN <introduction-to-wireguard-vpn>`
+   * {ref}`How to set up WireGuard VPN <how-to-wireguard-vpn>`
+
+1. **OpenVPN**
+   
+   * {ref}`About OpenVPN clients <openvpn-client-implementations>`
+   * {ref}`How to install OpenVPN <install-openvpn>`
+
+### Security of communications
+
+1. **TLS/SSL** for secure communication
+
+<!--- We don't have specific pages on TLS or SSL individually, but we do have:
+We don't have pages on TLS or SSL individually, but we do have:
+How-to: LDAP: {ref}`LDAP and TLS <ldap-and-tls>` (this is the closest we have to a discussion of the topic, and it’s within the how-to LDAP section)
+Explanation: Cryptography: {ref}`GnuTLS <gnutls>`
+Explanation: Cryptography: {ref}`OpenSSL <openssl>`
+Explanation: Cryptography: {ref}`Troubleshooting TLS/SSL <troubleshooting-tls>`
+Explanation: security: {ref}`OpenVPN <openvpn-client-implementations>` which is a VPN in the SSL/TLS VPN stack (as opposed to an IPSec VPN)
+--->
+
+### Mandatory Access Controls (MAC)
+
+1. **AppArmor**
+   
+   * {ref}`How to set up AppArmor <apparmor>`
+
+### Cryptography / cryptographic libraries
+
+1. **Crypto libraries**
+
+   * {ref}`introduction-to-crypto-libraries`
+   * {ref}`About crypto libraries <explanation-cryptography>`
+
+1. **Certificates**
+
+   * {ref}`About certificates <certificates>`
+   * {ref}`Install root CA certificate in the trust store <install-a-root-ca-certificate-in-the-trust-store>`
+
+### Compliance and auditing
+
+If you need to adhere to specific industry standards, or are otherwise operating
+in a high security environment, refer to the
+[Ubuntu Security documentation](https://ubuntu.com/security/compliance-automation).
+
+
+
+


### PR DESCRIPTION
Adds an expanded introduction to security and a "suggestions" page that signposts all our other security-related content

(please don't merge yet, still not quite finished adding context to the suggestions page)
