### PR TITLE
Change console highlight syntax to bash

### DIFF
--- a/explanation/crypto/gnutls.md
+++ b/explanation/crypto/gnutls.md
@@ -83,7 +83,7 @@ A priority string can start with a single initial keyword, and then add or remov
 
 To see the resulting list of ciphers and algorithms from a priority string, one can use the `gnutls-cli` command-line tool. For example, to list all the ciphers and algorithms allowed with the priority string `SECURE256`:
 
-```console
+```bash
 $ gnutls-cli --list --priority SECURE256
 Cipher suites for SECURE256
 TLS_AES_256_GCM_SHA384                                  0x13, 0x02      TLS1.3
@@ -109,7 +109,7 @@ PK-signatures: SIGN-RSA-SHA384, SIGN-RSA-PSS-SHA384, SIGN-RSA-PSS-RSAE-SHA384, S
 
 You can manipulate the resulting set by manipulating the priority string. For example, to remove `CHACHA20-POLY1305` from the `SECURE256` set:
 
-```console
+```bash
 $ gnutls-cli --list --priority SECURE256:-CHACHA20-POLY1305
 Cipher suites for SECURE256:-CHACHA20-POLY1305
 TLS_AES_256_GCM_SHA384                                  0x13, 0x02      TLS1.3
@@ -176,13 +176,13 @@ default-priority-string = NORMAL:-VERS-TLS-ALL:+VERS-TLS1.3
 
 With our test server providing everything but TLSv1.3:
 
-```console
+```bash
 $ sudo openssl s_server -cert j-server.pem -key j-server.key -port 443 -no_tls1_3  -www
 ```
 
 Connections will fail:
 
-```console
+```bash
 $ gnutls-cli j-server.lxd
 Processed 125 CA certificate(s).
 Resolving 'j-server.lxd:443'...
@@ -193,14 +193,14 @@ Connecting to '10.0.100.87:443'...
 
 An application linked with GnuTLS will also fail:
 
-```console
+```bash
 $ lftp -c "cat https://j-server.lxd/status"
 cat: /status: Fatal error: gnutls_handshake: A TLS fatal alert has been received.
 ```
 
 But an application can override these settings, because it's only the priority string that is being manipulated in the GnuTLS config:
 
-```console
+```bash
 $ lftp -c "set ssl:priority NORMAL:+VERS-TLS-ALL; cat https://j-server.lxd/status" | grep ^New
 New, TLSv1.2, Cipher is ECDHE-RSA-AES256-GCM-SHA384
 ```
@@ -221,7 +221,7 @@ Note that setting the same key multiple times will append the new value to the p
 
 In this scenario, the application cannot override the config anymore:
 
-```console
+```bash
 $ lftp -c "set ssl:priority NORMAL:+VERS-TLS-ALL; cat https://j-server.lxd/status" | grep ^New
 cat: /status: Fatal error: gnutls_handshake: A TLS fatal alert has been received.
 ```
@@ -249,7 +249,7 @@ $ sudo openssl s_server -cert j-server.pem -key j-server.key -port 443 -ciphersu
 
 Our GnuTLS client will fail:
 
-```console
+```bash
 $ gnutls-cli j-server.lxd
 Processed 126 CA certificate(s).
 Resolving 'j-server.lxd:443'...
@@ -260,7 +260,7 @@ Connecting to '10.0.100.87:443'...
 
 And given GnuTLS' behaviour regarding re-enabling a cipher that was once removed, we cannot allow AES128 from the command line either:
 
-```console
+```bash
 $ gnutls-cli --priority="NORMAL:+AES-128-GCM"  j-server.lxd
 Processed 126 CA certificate(s).
 Resolving 'j-server.lxd:443'...

--- a/explanation/crypto/openssh-crypto-configuration.md
+++ b/explanation/crypto/openssh-crypto-configuration.md
@@ -61,7 +61,7 @@ Here are the configuration settings that control the cryptographic algorithms se
 
 To check what effect a configuration change has on the server, it's helpful to use the `-T` parameter and `grep` the output for the configuration key you want to inspect. For example, to check the current value of the `Ciphers` configuration setting after having set `Ciphers ^3des-cbc` in `sshd_config`:
 
-```console
+```bash
 $ sudo sshd -T | grep ciphers
 
 ciphers 3des-cbc,chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
@@ -79,7 +79,7 @@ One way to examine which algorithm was selected is to add the `-v` parameter to 
 
 For example, assuming password-less public key authentication is being used (so no password prompt), we can use this command to initiate the connection and exit right away:
 
-```console
+```bash
 $ ssh -v <server> exit 2>&1 | grep "cipher:"
 
 debug1: kex: server->client cipher: chacha20-poly1305@openssh.com MAC: <implicit> compression: none
@@ -88,7 +88,7 @@ debug1: kex: client->server cipher: chacha20-poly1305@openssh.com MAC: <implicit
 
 In the above case, the `chacha20` cipher was automatically selected. We can influence this decision and only offer one algorithm:
 
-```console
+```bash
 $ ssh -v -c aes128-ctr <server> exit 2>&1 | grep "cipher:"
 
 debug1: kex: server->client cipher: aes128-ctr MAC: umac-64-etm@openssh.com compression: none
@@ -103,7 +103,7 @@ Let's configure an OpenSSH server to only offer the AES 256 bit variant of symme
 
 First, let's see what the default is:
 
-```console
+```bash
 $ sudo sshd -T | grep ciphers
 
 ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
@@ -131,7 +131,7 @@ $ sudo systemctl restart ssh.service
 
 After we restart the service, clients will no longer be able to use AES 128 to connect to it:
 
-```console
+```bash
 $ ssh -c aes128-ctr <server>
 
 Unable to negotiate with 10.0.102.49 port 22: no matching cipher found. Their offer: chacha20-poly1305@openssh.com,aes192-ctr,aes256-ctr,aes256-gcm@openssh.com
@@ -141,7 +141,7 @@ Unable to negotiate with 10.0.102.49 port 22: no matching cipher found. Their of
 
 If we just want to prioritise a particular cipher, we can use the "`^`" character to move it to the front of the list, without disabling any other cipher:
 
-```console
+```bash
 $ ssh -c ^aes256-ctr -v <server> exit 2>&1 | grep "cipher:"
 
 debug1: kex: server->client cipher: aes256-ctr MAC: umac-64-etm@openssh.com compression: none
@@ -150,7 +150,7 @@ debug1: kex: client->server cipher: aes256-ctr MAC: umac-64-etm@openssh.com comp
 
 In this way, if the server we are connecting to does not support AES 256, the negotiation will pick up the next one from the list. If we do that on the server via `Ciphers -aes256*`, this is what the same client, with the same command line, now reports:
 
-```console
+```bash
 $ ssh -c ^aes256-ctr -v <server> exit 2>&1 | grep "cipher:"
 
 debug1: kex: server->client cipher: chacha20-poly1305@openssh.com MAC: <implicit> compression: none

--- a/explanation/crypto/troubleshooting-tls-ssl.md
+++ b/explanation/crypto/troubleshooting-tls-ssl.md
@@ -43,14 +43,14 @@ $ echo | openssl s_client -connect server:port 2>&1 | grep ^New
 
 That will generally show the TLS version used, and the selected cipher:
 
-```console
+```bash
 $ echo | openssl s_client -connect j-server.lxd:443 2>&1  | grep ^New
 New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
 ```
 
 The ciphers and protocols can also be selected with the same command line options as the server:
 
-```console
+```bash
 $ echo | openssl s_client -connect j-server.lxd:443 -no_tls1_3 2>&1  | grep ^New
 New, TLSv1.2, Cipher is ECDHE-RSA-AES256-GCM-SHA384
 

--- a/explanation/intro-to/crypto-libraries.md
+++ b/explanation/intro-to/crypto-libraries.md
@@ -65,14 +65,14 @@ The package dependencies are a good way to check what is needed at runtime by th
 
 To find out the package that owns a file, use `dpkg -S`. For example:
 
-```console
+```bash
 $ dpkg -S /usr/bin/lynx
 lynx: /usr/bin/lynx
 ```
 
 Then, with the package name in hand, check its dependencies. It's best to also look for `Recommends`, as they are installed by default. Continuing with the example from before, we have:
 
-```console
+```bash
 $ dpkg -s lynx | grep -E "^(Depends|Recommends)"
 Depends: libbsd0 (>= 0.0), libbz2-1.0, libc6 (>= 2.34), libgnutls30 (>= 3.7.0), libidn2-0 (>= 2.0.0), libncursesw6 (>= 6), libtinfo6 (>= 6), zlib1g (>= 1:1.1.4), lynx-common
 Recommends: mime-support
@@ -86,7 +86,7 @@ The dynamic libraries that are needed by an application should always be correct
 
 A very helpful tool that is installed in all Ubuntu systems is `ldd`. It will list all the dynamic libraries that are needed by the given binary, including dependencies of dependencies, i.e. it's recursive. Going back to the `lynx` example:
 
-```console
+```bash
 $ ldd /usr/bin/lynx
     linux-vdso.so.1 (0x00007ffffd2df000)
     libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007feb69d77000)
@@ -114,7 +114,7 @@ Another way to check for such dependencies, but without the recursion, is via `o
 
 The way to use it is to grep for the `NEEDED` string:
 
-```console
+```bash
 $ objdump -x /usr/bin/lynx|grep NEEDED
   NEEDED               libz.so.1
   NEEDED               libbz2.so.1.0
@@ -128,7 +128,7 @@ $ objdump -x /usr/bin/lynx|grep NEEDED
 
 Finally, if you want to see the dependency *tree*, you can use `lddtree` from the `pax-utils` package:
 
-```console
+```bash
 $ lddtree /usr/bin/lynx
 lynx => /usr/bin/lynx (interpreter => /lib64/ld-linux-x86-64.so.2)
     libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1
@@ -159,14 +159,14 @@ Identifying which libraries were used in a static build is a bit more involved. 
 
 For example, let's try to discover which crypto libraries, if any, the `rclone` tool uses. First, let's try the packaging dependencies:
 
-```console
+```bash
 $ dpkg -s rclone | grep -E "^(Depends|Recommends)"
 Depends: libc6 (>= 2.34)
 ```
 
 Uh, that's a short list. But `rclone` definitely supports encryption, so what is going on? Turns out this is a tool written in the Go language, and that uses static linking of libraries. So let's try to inspect the package data more carefully, and this time look for the `Built-Using` header:
 
-```console
+```bash
 $ dpkg -s rclone | grep Built-Using
 Built-Using: go-md2man-v2 (= 2.0.1+ds1-1), golang-1.18 (= 1.18-1ubuntu1), golang-bazil-fuse (= 0.0~git20160811.0.371fbbd-3), ...
 ```
@@ -175,7 +175,7 @@ Ok, this time we have a lot of information (truncated above for brevity, since i
 
 If the `Built-Using` header was not there, or didn't yield any clues, we could try one more step and look for the build dependencies. These can be found in the `debian/control` file of the source package. In the case of `rclone` for Ubuntu Jammy, that can be seen at https://git.launchpad.net/ubuntu/+source/rclone/tree/debian/control?h=ubuntu/jammy-devel#n7, and a quick look at the `Build-Depends` list shows us the `golang-golang-x-crypto-dev` build dependency, whose source package is `golang-go.crypto` as expected:
 
-```console
+```bash
 $ apt-cache show golang-golang-x-crypto-dev | grep ^Source:
 Source: golang-go.crypto
 ```

--- a/explanation/virtualisation/upgrading-the-machine-type-of-your-vm.md
+++ b/explanation/virtualisation/upgrading-the-machine-type-of-your-vm.md
@@ -34,13 +34,13 @@ There is no integrated single command to update the machine type via `virsh` or 
 
 First shutdown your machine and wait until it has reached that state:
 
-```console
+```bash
 virsh shutdown <your_machine>
 ```
 
 You can check the status of the machine with the following command:
 
-```console
+```bash
 virsh list --inactive
 ```
 
@@ -48,14 +48,14 @@ virsh list --inactive
 
 Once the machine is listed as "shut off", you can then edit the machine definition and find the type in the `type` tag given at the machine attribute.
 
-```console
+```bash
 virsh edit <your_machine>
 <type arch='x86_64' machine='pc-i440fx-bionic'>hvm</type>
 ```
 
 Change this to the value you want. If you need to check what machine types are available via the `kvm -M ?` command first, then note that while upstream types are provided for convenience, only Ubuntu types are supported. There you can also see what the current default would be, as in this example: 
 
-```console
+```bash
 $ kvm -M ?
 pc-i440fx-xenial       Ubuntu 16.04 PC (i440FX + PIIX, 1996) (default)
 ...
@@ -69,7 +69,7 @@ We strongly recommend that you change to newer types (if possible), not only to 
 
 After this you can start your guest again. You can check the current machine type from guest and host depending on your needs.
 
-```console
+```bash
 virsh start <your_machine>
 # check from host, via dumping the active xml definition
 virsh dumpxml <your_machine> | xmllint --xpath "string(//domain/os/type/@machine)" -

--- a/how-to/backups/back-up-using-shell-scripts.md
+++ b/how-to/backups/back-up-using-shell-scripts.md
@@ -71,7 +71,7 @@ The `cron` utility can be used to automate use of the script. The `cron` daemon 
 
 `cron` is configured through entries in a `crontab` file. `crontab` files are separated into fields:
 
-```console
+```bash
 # m h dom mon dow   command
 ```
 

--- a/how-to/backups/install-rsnapshot.md
+++ b/how-to/backups/install-rsnapshot.md
@@ -19,7 +19,7 @@ The `rsnapshot` configuration resides in `/etc/rsnapshot.conf`. Below you can fi
 
 The root directory where all snapshots will be stored is found at:
 
-```console
+```bash
 snapshot_root       /var/cache/rsnapshot/
 ```
 
@@ -27,7 +27,7 @@ snapshot_root       /var/cache/rsnapshot/
 
 Since `rsnapshot` uses incremental backups, we can afford to keep older backups for a while before removing them. You set these up under the `BACKUP LEVELS / INTERVALS` section. You can tell `rsnapshot` to retain a specific number of backups of each kind of interval. 
 
-```console
+```bash
 retain  daily   6
 retain  weekly    7
 retain  monthly   4
@@ -39,7 +39,7 @@ In this example we will keep 6 snapshots of our daily strategy, 7 snapshots of o
 
 If you are accessing a remote machine over SSH and the port to bind is not the default (port `22`), you need to set the following variable with the port number:
 
-```console
+```bash
 ssh_args       -p 22222
 ```
 
@@ -49,7 +49,7 @@ Now the most important part; you need to decide what you would like to backup.
 
 If you are backing up locally to the same machine, this is as easy as specifying the directories that you want to save and following it with `localhost/` which will be a sub-directory in the `snapshot_root` that you set up earlier.
 
-```console
+```bash
 backup  /home/          localhost/
 backup  /etc/           localhost/
 backup  /usr/local/     localhost/
@@ -57,7 +57,7 @@ backup  /usr/local/     localhost/
 
 If you are backing up a remote machine you just need to tell `rsnapshot` where the server is and which directories you would like to back up.
 
-```console
+```bash
 backup root@example.com:/home/ example.com/    +rsync_long_args=--bwlimit=16,exclude=core
 backup root@example.com:/etc/  example.com/    exclude=mtab,exclude=core
 ```


### PR DESCRIPTION
Closes #40

This update changes all the "console" syntax highlights to "bash"
For example, code blocks tend to go from

![image](https://github.com/user-attachments/assets/852f4f9f-a4e0-4664-a432-0082c036dcf6)

to

![image](https://github.com/user-attachments/assets/f2f9ec1c-0f74-429d-9c34-41664dc497af)

LMK if you think this is better. Also as a side note, it would probably be a good idea to clean up code blocks such that all commands consistently include or remove the `$` at the beginning. That should also help clean up the syntax highlighting a bit.