### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,57 @@
+<!-- You can erase any parts of this template not applicable to your Pull Request. -->
+
+
+### Description
+Please provide a clear and concise description of your changes. Explain **what** this pull request accomplishes and *
+*why** it is needed.
+
+---
+
+### Related Issue
+
+If this pull request addresses an existing issue, please link to it below. Use the `Fixes #<issue-number>` syntax to
+close the issue automatically when the pull request is merged.
+
+Example:
+
+- Fixes: #1234
+
+---
+
+### Contributor License Agreement (CLA)
+
+By contributing to this project, you agree to the terms of
+the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
+If you have not already signed the CLA, please do so [here](https://ubuntu.com/legal/contributors).
+
+---
+
+### Commit Message for Squash Merge
+
+If this pull request is merged with the squash option, what should the commit message be?  
+Provide the desired commit message below:
+
+Example:
+[Category] Brief description of changes made
+
+---
+
+### Checklist
+
+- [ ] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
+- [ ] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
+- [ ] My changes are well-documented, and I have updated the documentation as needed.
+- [ ] My pull request is linked to an existing issue (if applicable).
+- [ ] I have tested my changes, and they work as expected.
+- [ ] New and existing unit tests pass locally with my changes.
+
+---
+
+### Additional Notes (Optional)
+
+Add any extra information or context that reviewers may need to know. This could include testing instructions,
+screenshots, or links to related discussions.
+
+---
+
+Thank you for contributing to the Ubuntu Server documentation!


### PR DESCRIPTION
### Description

The problem:

We are currently lacking a nicely-formatted Pull Request template.

What is needed:

It should include:

a link to the [Contributor License Agreement](https://ubuntu.com/legal/contributors)
a reminder to [sign the CLA](https://ubuntu.com/legal/contributors/agreement), if the contributor has not already
Fixes: #1234 as a reminder to include the corresponding issue number, if the PR fixes an open issue
a space for a commit message that the author wants to be applied to a squash merge
Suggestions:

We currently don't have a PR template at all. There is some helpful guidance in the [GitHub documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) about creating PR templates.

---


### Related Issue

- Fixes: #11 


---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My changes are well-documented, and I have updated the documentation as needed.
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
- [x] New and existing unit tests pass locally with my changes.

---
