### PR TITLE
Create an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE /feedback.yml
+++ b/.github/ISSUE_TEMPLATE /feedback.yml
@@ -1,0 +1,51 @@
+name: Feedback
+description: Provide feedback on the Ubuntu Server documentation.
+title: "[Feedback]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thanks for taking the time to fill out this feedback!**
+        We really appreciate your input, and it will help us improve the documentation.
+        
+        Please provide an appropriate title, usually found at the top of the page.
+        
+        ---
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      description: Please enter the URL of the page you are referring to.
+      type: url
+    validations:
+      required: true
+  - type: checkboxes
+    id: content
+    attributes:
+      label: Select an option
+      description: Please let us know what issue you encountered with the documentation.
+      options:
+        - label: I found what I was looking for
+          required: false
+        - label: I couldn't find what I was looking for
+          required: false
+        - label: I found the information, but it was incorrect
+          required: false
+        - label: I found the information, but it was incomplete
+          required: false
+        - label: I found the information, but it was confusing
+          required: false
+        - label: I encountered a technical issue (e.g., broken link, image not loading)
+          required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: |
+        Please provide a detailed description of the issue:
+        - What part of the documentation were you trying to use?
+        - What did you expect to happen, and what actually happened?
+        - Any error messages or screenshots you can provide would be very helpful.
+    validations:
+      required: true
+      

--- a/.sphinx/_static/github_issue_links.js
+++ b/.sphinx/_static/github_issue_links.js
@@ -11,18 +11,8 @@ window.onload = function() {
     link.classList.add("muted-link");
     link.classList.add("github-issue-link");
     link.text = "Give feedback";
-    link.href = (
-        github_url
-        + "/issues/new?"
-        + "title=docs%3A+TYPE+YOUR+QUESTION+HERE"
-        + "&body=*Please describe the question or issue you're facing with "
-        + `"${document.title}"`
-        + ".*"
-        + "%0A%0A%0A%0A%0A"
-        + "---"
-        + "%0A"
-        + `*Reported+from%3A+${location.href}*`
-    );
+    // use the issue template in the .github/ISSUE_TEMPLATE/feedback.yml file
+    link.href = github_url + "/issues/new?template=feedback.yml";
     link.target = "_blank";
 
     const div = document.createElement("div");

--- a/explanation/performance/perf-tune-tuned.md
+++ b/explanation/performance/perf-tune-tuned.md
@@ -21,7 +21,7 @@ You can also configure TuneD to dynamically react to changes in device usage and
 
 ## Static vs. dynamic tuning
 
-TuneD can perform two types of tuning: **static** and **dynamic**. 
+TuneD can perform two types of tuning: **static** and **dynamic**.
 
 * Static tuning mainly consists of applying predefined `sysctl` and `sysfs` settings and the one-shot activation of several configuration tools such as `ethtool`.
 
@@ -128,7 +128,7 @@ cpu
 ```
 And their description can be found in `/usr/lib/python3/dist-packages/tuned/plugins/plugin_cpu.py`.
 
-### Customising a profile 
+### Customising a profile
 
 For some specific workloads, the predefined profiles might not be enough and you may want to customise your own profile. You may customise an existing profile, just overriding a few settings, or create an entirely new one.
 

--- a/explanation/performance/perf-tune-tuned.md
+++ b/explanation/performance/perf-tune-tuned.md
@@ -41,7 +41,21 @@ TuneD works with profiles, which are configuration files grouping tuning plugins
 | Other cases | `balanced` |
 
 ### Anatomy of a profile
-Tuned profiles are defined by directory in `/usr/lib/tuned/<profile>` or `/etc/tuned/<profile>`, and are defined in a `tuned.conf` file within that directory.  That file has an INI structure which looks like this:
+
+Predefined tuned profiles provided by the package are located in the directory `/usr/lib/tuned/<profile>`,
+those added by the administrator should be placed in `/etc/tuned/<profile>`.
+
+> In tuned version 2.24 and thereby Ubuntu 25.04 Plucky (and later) the location
+> of these files changed. An upgrade will migrate custom profiles, since most
+> users are not yet on that new release the further document will use the old
+> paths in the examples.
+> Predefined profiles:
+>   `/usr/lib/tuned/<profile>` -> `/usr/lib/tuned/profiles/<profile>`
+> User defined profiles:
+>   `/etc/tuned/<profile>` -> `/etc/tuned/profiles/<profile>`
+
+In each of these `<profile>` directories a file `tuned.conf` defines that profile.
+That file has an INI structure which looks like this:
 
 ```ini
 [main]
@@ -132,7 +146,7 @@ And their description can be found in `/usr/lib/python3/dist-packages/tuned/plug
 
 For some specific workloads, the predefined profiles might not be enough and you may want to customise your own profile. You may customise an existing profile, just overriding a few settings, or create an entirely new one.
 
-Custom profiles live in `/etc/tuned/<profile>/tuned.conf`. There are 3 ways they can be created:
+Custom profiles live in `/etc/tuned/<profile>/tuned.conf` (Remember this location changed in 25.04 Plucky and later). There are 3 ways they can be created:
 
 * Copy an existing profile from `/usr/lib/tuned/<profile>` to `/etc/tuned/<profile>`, and make changes to it in that location. A profile defined in `/etc/tuned` takes precedence over one from `/usr/lib/tuned` with the same name.
 * Create an entirely new profile in `/etc/tuned/<profile>` from scratch.

--- a/explanation/performance/perf-tune-tuned.md
+++ b/explanation/performance/perf-tune-tuned.md
@@ -45,10 +45,10 @@ TuneD works with profiles, which are configuration files grouping tuning plugins
 Predefined tuned profiles provided by the package are located in the directory `/usr/lib/tuned/<profile-name>`,
 those added by the administrator should be placed in `/etc/tuned/<profile-name>`.
 
-> In tuned version 2.24 and thereby Ubuntu 25.04 Plucky (and later) the location
-> of these files changed. An upgrade will migrate custom profiles, since most
-> users are not yet on that new release the further document will use the old
-> paths in the examples.
+> In TuneD version 2.24 and thereby Ubuntu 25.04 Plucky (and later) the location
+> of these files changed. An upgrade will migrate any custom profiles, however
+> since most users are not yet on the new release, the rest of this page uses
+> the old paths in the examples.
 > Predefined profiles:
 >   `/usr/lib/tuned/<profile-name>` -> `/usr/lib/tuned/profiles/<profile-name>`
 > User defined profiles:

--- a/explanation/performance/perf-tune-tuned.md
+++ b/explanation/performance/perf-tune-tuned.md
@@ -245,8 +245,6 @@ The sections that follow `[main]` represent the configuration of tuning plugins.
 * The second plugin used is `disk`, which is used to set the `readahead` value to at least `4096`.
 * Finally, the `sysctl` plugin is configured to set several variables in `sysfs` (the comments in the example explain the rationale behind each change).
 
-The content of this profile can be overwritten if needed, by creating the file `/etc/tuned/hpc-compute/tuned.conf` with the desired content. The content in `/etc/tuned` always takes precedence over `/usr/lib/tuned`. One can also extend this profile by creating a custom profile and including `hpc-compute`.
-
 > \*1: This is a universe package
 > Ubuntu ships this software as part of its [universe repository](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/explanations/about_esm/#what-are-main-and-universe), which is maintained by volunteers from the Ubuntu community. Canonical also offers [Ubuntu Pro](https://ubuntu.com/pro) – a free-for-personal-use subscription that provides a 10 year [security maintenance commitment](https://ubuntu.com/security/esm).
 

--- a/explanation/performance/perf-tune-tuned.md
+++ b/explanation/performance/perf-tune-tuned.md
@@ -42,19 +42,19 @@ TuneD works with profiles, which are configuration files grouping tuning plugins
 
 ### Anatomy of a profile
 
-Predefined tuned profiles provided by the package are located in the directory `/usr/lib/tuned/<profile>`,
-those added by the administrator should be placed in `/etc/tuned/<profile>`.
+Predefined tuned profiles provided by the package are located in the directory `/usr/lib/tuned/<profile-name>`,
+those added by the administrator should be placed in `/etc/tuned/<profile-name>`.
 
 > In tuned version 2.24 and thereby Ubuntu 25.04 Plucky (and later) the location
 > of these files changed. An upgrade will migrate custom profiles, since most
 > users are not yet on that new release the further document will use the old
 > paths in the examples.
 > Predefined profiles:
->   `/usr/lib/tuned/<profile>` -> `/usr/lib/tuned/profiles/<profile>`
+>   `/usr/lib/tuned/<profile-name>` -> `/usr/lib/tuned/profiles/<profile-name>`
 > User defined profiles:
->   `/etc/tuned/<profile>` -> `/etc/tuned/profiles/<profile>`
+>   `/etc/tuned/<profile-name>` -> `/etc/tuned/profiles/<profile-name>`
 
-In each of these `<profile>` directories a file `tuned.conf` defines that profile.
+In each of these `<profile-name>` directories a file `tuned.conf` defines that profile.
 That file has an INI structure which looks like this:
 
 ```ini
@@ -146,11 +146,11 @@ And their description can be found in `/usr/lib/python3/dist-packages/tuned/plug
 
 For some specific workloads, the predefined profiles might not be enough and you may want to customise your own profile. You may customise an existing profile, just overriding a few settings, or create an entirely new one.
 
-Custom profiles live in `/etc/tuned/<profile>/tuned.conf` (Remember this location changed in 25.04 Plucky and later). There are 3 ways they can be created:
+Custom profiles live in `/etc/tuned/<profile-name>/tuned.conf` (Remember this location changed in 25.04 Plucky and later). There are 3 ways they can be created:
 
-* Copy an existing profile from `/usr/lib/tuned/<profile>` to `/etc/tuned/<profile>`, and make changes to it in that location. A profile defined in `/etc/tuned` takes precedence over one from `/usr/lib/tuned` with the same name.
-* Create an entirely new profile in `/etc/tuned/<profile>` from scratch.
-* Create a new profile in `/etc/tuned/<new-profile>`, with a name that doesn't match an existing profile, and inherit from another profile. In this way you only have to specify the changes you want, and inherit the rest from the existing profile in `/usr/lib/tuned/<profile>`.
+* Copy an existing profile from `/usr/lib/tuned/<profile-name>` to `/etc/tuned/<profile-name>`, and make changes to it in that location. A profile defined in `/etc/tuned` takes precedence over one from `/usr/lib/tuned` with the same name.
+* Create an entirely new profile in `/etc/tuned/<new-profile-name>` from scratch.
+* Create a new profile in `/etc/tuned/<new-profile-name>`, with a name that doesn't match an existing profile, and inherit from another profile. In this way you only have to specify the changes you want, and inherit the rest from the existing profile in `/usr/lib/tuned/<profile-name>`.
 
 After that, the new profile will be visible by TuneD via the `tuned-adm list` command.
 


### PR DESCRIPTION
This PR solves [ubuntu-server-documentation issue #12 ](https://github.com/canonical/ubuntu-server-documentation/issues/12) and [open-documentation-academy issue #153](https://github.com/canonical/open-documentation-academy/issues/153) by introducing an issue template in `.github/ISSUE_TEMPLATE/feedback.yml` to guide readers in providing detailed and structured feedback. 

The new template includes:

- A checkbox list for readers to specify the type of issue they encountered.
- A mandatory input field for the page URL.
- A mandatory textarea for a detailed description of the issue, with prompts to include specific details like expected vs. actual outcomes, error messages, or screenshots.