### PR TITLE
Create an issue template for the "Give feedback" button

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,51 @@
+name: Feedback
+description: Provide feedback on the Ubuntu Server documentation.
+title: "[Feedback]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thanks for taking the time to fill out this feedback!**
+        We really appreciate your input, and it will help us improve the documentation.
+        
+        Please provide an appropriate title, usually found at the top of the page.
+        
+        ---
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      description: Please enter the URL of the page you are referring to.
+      type: url
+    validations:
+      required: true
+  - type: checkboxes
+    id: content
+    attributes:
+      label: Select an option
+      description: Please let us know what issue you encountered with the documentation.
+      options:
+        - label: I found what I was looking for
+          required: false
+        - label: I couldn't find what I was looking for
+          required: false
+        - label: I found the information, but it was incorrect
+          required: false
+        - label: I found the information, but it was incomplete
+          required: false
+        - label: I found the information, but it was confusing
+          required: false
+        - label: I encountered a technical issue (e.g., broken link, image not loading)
+          required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: |
+        Please provide a detailed description of the issue:
+        - What part of the documentation were you trying to use?
+        - What did you expect to happen, and what actually happened?
+        - Any error messages or screenshots you can provide would be very helpful.
+    validations:
+      required: true
+      

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: Page URL
       description: Please enter the URL of the page you are referring to.
-      type: url
+      placeholder: https://documentation.ubuntu.com/server/
     validations:
       required: true
   - type: checkboxes
@@ -26,17 +26,11 @@ body:
       description: Please let us know what issue you encountered with the documentation.
       options:
         - label: I found what I was looking for
-          required: false
         - label: I couldn't find what I was looking for
-          required: false
         - label: I found the information, but it was incorrect
-          required: false
         - label: I found the information, but it was incomplete
-          required: false
         - label: I found the information, but it was confusing
-          required: false
         - label: I encountered a technical issue (e.g., broken link, image not loading)
-          required: false
   - type: textarea
     id: description
     attributes:
@@ -48,4 +42,3 @@ body:
         - Any error messages or screenshots you can provide would be very helpful.
     validations:
       required: true
-      

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -8,7 +8,7 @@ body:
         **Thanks for taking the time to fill out this feedback!**
         We really appreciate your input, and it will help us improve the documentation.
         
-        Please provide an appropriate title, usually found at the top of the page.
+        Please provide an appropriate title at the top of this page.
         
         ---
   - type: input

--- a/.sphinx/_static/github_issue_links.js
+++ b/.sphinx/_static/github_issue_links.js
@@ -11,18 +11,8 @@ window.onload = function() {
     link.classList.add("muted-link");
     link.classList.add("github-issue-link");
     link.text = "Give feedback";
-    link.href = (
-        github_url
-        + "/issues/new?"
-        + "title=docs%3A+TYPE+YOUR+QUESTION+HERE"
-        + "&body=*Please describe the question or issue you're facing with "
-        + `"${document.title}"`
-        + ".*"
-        + "%0A%0A%0A%0A%0A"
-        + "---"
-        + "%0A"
-        + `*Reported+from%3A+${location.href}*`
-    );
+    // use the issue template in the .github/ISSUE_TEMPLATE/feedback.yml file
+    link.href = github_url + "/issues/new?template=feedback.yml";
     link.target = "_blank";
 
     const div = document.createElement("div");


### PR DESCRIPTION
This PR solves [ubuntu-server-documentation issue #12 ](https://github.com/canonical/ubuntu-server-documentation/issues/12) and [open-documentation-academy issue #153](https://github.com/canonical/open-documentation-academy/issues/153) by introducing an issue template in `.github/ISSUE_TEMPLATE/feedback.yml` to guide readers in providing detailed and structured feedback. 

The new template includes:

- A checkbox list for readers to specify the type of issue they encountered.
- A mandatory input field for the page URL.
- A mandatory textarea for a detailed description of the issue, with prompts to include specific details like expected vs. actual outcomes, error messages, or screenshots.