### PR TITLE
Documentation: Add glossary

### DIFF
--- a/how-to/openldap/access-control.md
+++ b/how-to/openldap/access-control.md
@@ -2,7 +2,7 @@
 # Set up LDAP access control
 
 
-The management of what type of access (read, write, etc) users should be granted for resources is known as **access control**. The configuration directives involved are called **access control lists** or ACLs.
+The management of what type of access (read, write, etc) users should be granted for resources is known as **access control**. The configuration directives involved are called **access control lists** or {term}`ACLs`.
 
 When we {ref}`installed the slapd package <install-openldap>`, various ACLs were set up automatically. We will look at a few important consequences of those defaults and, in so doing, we'll get an idea of how ACLs work and how they're configured.
 

--- a/reference/glossary.rst
+++ b/reference/glossary.rst
@@ -1,0 +1,3188 @@
+.. caution::
+
+    We are currently compiling and defining terms for this glossary. If you would like to help, please visit our :doc:`contributions page <../contributing/index>` for details on how to get involved.
+
+Glossary
+========
+
+.. glossary::
+
+    aarch
+        *Work in Progress*
+
+    ABI
+        *Work in Progress*
+
+    accesslog
+        *Work in Progress*
+
+    accroding
+        *Work in Progress*
+
+    ACL
+        *Work in Progress*
+
+    acl
+        *Work in Progress*
+
+    ACLs
+        *Work in Progress*
+
+    adapter
+        *Work in Progress*
+
+    adapter's
+        *Work in Progress*
+
+    adapters
+        *Work in Progress*
+
+    adaptively
+        *Work in Progress*
+
+    adm
+        *Work in Progress*
+
+    ADSys
+        *Work in Progress*
+
+    AES
+        *Work in Progress*
+
+    Alertmanager
+        *Work in Progress*
+
+    ALSA
+        *Work in Progress*
+
+    ALUA
+        *Work in Progress*
+
+    amd
+        *Work in Progress*
+
+    AMD
+        *Work in Progress*
+
+    Ansible
+        *Work in Progress*
+
+    apache
+        *Work in Progress*
+
+    Apache2
+        *Work in Progress*
+
+    apparmor
+        *Work in Progress*
+
+    Apparmor
+        *Work in Progress*
+
+    AppArmor
+        *Work in Progress*
+
+    Apport
+        *Work in Progress*
+
+    APT
+        *Work in Progress*
+
+    APT's
+        *Work in Progress*
+
+    architected
+        *Work in Progress*
+
+    armhf
+        *Work in Progress*
+
+    ARP
+        *Work in Progress*
+
+    ArrayBolt
+        *Work in Progress*
+
+    AskUbuntu
+        *Work in Progress*
+
+    async
+        *Work in Progress*
+
+    AUTH
+        *Work in Progress*
+
+    auth
+        *Work in Progress*
+
+    authenticatoin
+        *Work in Progress*
+
+    Authenticator
+        *Work in Progress*
+
+    authorized
+        *Work in Progress*
+
+    autocommit
+        *Work in Progress*
+
+    autodetect
+        *Work in Progress*
+
+    autodetected
+        *Work in Progress*
+
+    autoinstall
+        *Work in Progress*
+
+    autoinstallation
+        *Work in Progress*
+
+    Autoinstallation
+        *Work in Progress*
+
+    autorid
+        *Work in Progress*
+
+    AWS
+        *Work in Progress*
+
+    awslogs
+        *Work in Progress*
+
+    AX
+        *Work in Progress*
+
+    backend
+        *Work in Progress*
+
+    backends
+        *Work in Progress*
+
+    Backports
+        *Work in Progress*
+
+    Backtrace
+        *Work in Progress*
+
+    BackupServer
+        *Work in Progress*
+
+    bacula
+        *Work in Progress*
+
+    Bacula
+        *Work in Progress*
+
+    BDC
+        *Work in Progress*
+
+    bdev
+        *Work in Progress*
+
+    behavior
+        *Work in Progress*
+
+    Berkley
+        *Work in Progress*
+
+    BindDN
+        *Work in Progress*
+
+    BMC
+        *Work in Progress*
+
+    BMC's
+        *Work in Progress*
+
+    bootable
+        *Work in Progress*
+
+    bootloader
+        *Work in Progress*
+
+    bootloaders
+        *Work in Progress*
+
+    bootp
+        *Work in Progress*
+
+    bootstrap
+        *Work in Progress*
+
+    BSD
+        *Work in Progress*
+
+    btrfs
+        *Work in Progress*
+
+    Btrfs
+        *Work in Progress*
+
+    bugfix
+        *Work in Progress*
+
+    byobu
+        *Work in Progress*
+
+    Byobu
+        *Work in Progress*
+
+    CA
+        *Work in Progress*
+
+    CA's
+        *Work in Progress*
+
+    CAC
+        *Work in Progress*
+
+    CARP
+        *Work in Progress*
+
+    CAs
+        *Work in Progress*
+
+    Catalog
+        *Work in Progress*
+
+    CCID
+        *Work in Progress*
+
+    ccw
+        *Work in Progress*
+
+    CDBs
+        *Work in Progress*
+
+    CDROM
+        *Work in Progress*
+
+    center
+        *Work in Progress*
+
+    Center
+        *Work in Progress*
+
+    CentOS
+        *Work in Progress*
+
+    centric
+        *Work in Progress*
+
+    certmap
+        *Work in Progress*
+
+    certutil
+        *Work in Progress*
+
+    cfg
+        *Work in Progress*
+
+    cgi
+        *Work in Progress*
+
+    CGNAT
+        *Work in Progress*
+
+    cgroup
+        *Work in Progress*
+
+    cgroups
+        *Work in Progress*
+
+    CHACHA
+        *Work in Progress*
+
+    chage
+        *Work in Progress*
+
+    checksumming
+        *Work in Progress*
+
+    checksums
+        *Work in Progress*
+
+    checkzone
+        *Work in Progress*
+
+    chrony
+        *Work in Progress*
+
+    chroot
+        *Work in Progress*
+
+    CIDR
+        *Work in Progress*
+
+    CIFS
+        *Work in Progress*
+
+    cifs
+        *Work in Progress*
+
+    cipherlist
+        *Work in Progress*
+
+    CipherString
+        *Work in Progress*
+
+    ciphersuites
+        *Work in Progress*
+
+    CipherSuites
+        *Work in Progress*
+
+    CIS
+        *Work in Progress*
+
+    CLARiiON
+        *Work in Progress*
+
+    cleartext
+        *Work in Progress*
+
+    Cloudwatch
+        *Work in Progress*
+
+    CloudWatch
+        *Work in Progress*
+
+    ClusterLabs
+        *Work in Progress*
+
+    clvm
+        *Work in Progress*
+
+    CLVM
+        *Work in Progress*
+
+    clvmd
+        *Work in Progress*
+
+    cLVMd
+        *Work in Progress*
+
+    cmd
+        *Work in Progress*
+
+    CMS
+        *Work in Progress*
+
+    CMSs
+        *Work in Progress*
+
+    cn
+        *Work in Progress*
+
+    CN
+        *Work in Progress*
+
+    codename
+        *Work in Progress*
+
+    colocation
+        *Work in Progress*
+
+    color
+        *Work in Progress*
+
+    Colors
+        *Work in Progress*
+
+    colors
+        *Work in Progress*
+
+    comand
+        *Work in Progress*
+
+    conf
+        *Work in Progress*
+
+    conffile
+        *Work in Progress*
+
+    config
+        *Work in Progress*
+
+    connectionless
+        *Work in Progress*
+
+    containerization
+        *Work in Progress*
+
+    containerize
+        *Work in Progress*
+
+    corei
+        *Work in Progress*
+
+    coreutils
+        *Work in Progress*
+
+    corosync
+        *Work in Progress*
+
+    Corosync
+        *Work in Progress*
+
+    cpu
+        *Work in Progress*
+
+    CPUs
+        *Work in Progress*
+
+    CRL
+        *Work in Progress*
+
+    CRLs
+        *Work in Progress*
+
+    crmsh
+        *Work in Progress*
+
+    cron
+        *Work in Progress*
+
+    CronHowto
+        *Work in Progress*
+
+    crypto
+        *Work in Progress*
+
+    cryptographic
+        *Work in Progress*
+
+    cryptographically
+        *Work in Progress*
+
+    CSR
+        *Work in Progress*
+
+    csync
+        *Work in Progress*
+
+    ctrl
+        *Work in Progress*
+
+    Ctrl
+        *Work in Progress*
+
+    CTX
+        *Work in Progress*
+
+    customisations
+        *Work in Progress*
+
+    Customization
+        *Work in Progress*
+
+    customization
+        *Work in Progress*
+
+    customizations
+        *Work in Progress*
+
+    customize
+        *Work in Progress*
+
+    customized
+        *Work in Progress*
+
+    customizing
+        *Work in Progress*
+
+    CustomLog
+        *Work in Progress*
+
+    CVE
+        *Work in Progress*
+
+    CX
+        *Work in Progress*
+
+    DAC
+        *Work in Progress*
+
+    daemonize
+        *Work in Progress*
+
+    Danika
+        *Work in Progress*
+
+    DARPA
+        *Work in Progress*
+
+    DASD
+        *Work in Progress*
+
+    datacentre
+        *Work in Progress*
+
+    Datagram
+        *Work in Progress*
+
+    dbgsym
+        *Work in Progress*
+
+    dblink
+        *Work in Progress*
+
+    DBs
+        *Work in Progress*
+
+    ddeb
+        *Work in Progress*
+
+    ddebs
+        *Work in Progress*
+
+    DDNS
+        *Work in Progress*
+
+    de
+        *Work in Progress*
+
+    debconf
+        *Work in Progress*
+
+    debian
+        *Work in Progress*
+
+    debuginfo
+        *Work in Progress*
+
+    debuginfod
+        *Work in Progress*
+
+    decrypt
+        *Work in Progress*
+
+    decrypted
+        *Work in Progress*
+
+    deduplication
+        *Work in Progress*
+
+    dee
+        *Work in Progress*
+
+    Defense
+        *Work in Progress*
+
+    denylist
+        *Work in Progress*
+
+    denylists
+        *Work in Progress*
+
+    DER
+        *Work in Progress*
+
+    dev
+        *Work in Progress*
+
+    devel
+        *Work in Progress*
+
+    DevStack
+        *Work in Progress*
+
+    DGC
+        *Work in Progress*
+
+    dhcp
+        *Work in Progress*
+
+    DHCP
+        *Work in Progress*
+
+    dhcpd
+        *Work in Progress*
+
+    dialogs
+        *Work in Progress*
+
+    Diffie
+        *Work in Progress*
+
+    dir
+        *Work in Progress*
+
+    DirectoryIndex
+        *Work in Progress*
+
+    disambiguating
+        *Work in Progress*
+
+    discoverable
+        *Work in Progress*
+
+    DIT
+        *Work in Progress*
+
+    DKMS
+        *Work in Progress*
+
+    DLM
+        *Work in Progress*
+
+    dm
+        *Work in Progress*
+
+    DM
+        *Work in Progress*
+
+    DMA
+        *Work in Progress*
+
+    DMAR
+        *Work in Progress*
+
+    dmesg
+        *Work in Progress*
+
+    dmsetup
+        *Work in Progress*
+
+    dn
+        *Work in Progress*
+
+    DN
+        *Work in Progress*
+
+    DNS
+        *Work in Progress*
+
+    DNs
+        *Work in Progress*
+
+    dnsleaktest
+        *Work in Progress*
+
+    dnsmasq
+        *Work in Progress*
+
+    DNSSEC
+        *Work in Progress*
+
+    Docker
+        *Work in Progress*
+
+    Docker's
+        *Work in Progress*
+
+    DocumentRoot
+        *Work in Progress*
+
+    dom
+        *Work in Progress*
+
+    DPDK
+        *Work in Progress*
+
+    dpdk
+        *Work in Progress*
+
+    DPDK's
+        *Work in Progress*
+
+    dpkg
+        *Work in Progress*
+
+    DPKG
+        *Work in Progress*
+
+    DRBD
+        *Work in Progress*
+
+    drbd
+        *Work in Progress*
+
+    drbdadm
+        *Work in Progress*
+
+    dsg
+        *Work in Progress*
+
+    dsi
+        *Work in Progress*
+
+    DTLS
+        *Work in Progress*
+
+    EAL
+        *Work in Progress*
+
+    EasyRSA
+        *Work in Progress*
+
+    ECKD
+        *Work in Progress*
+
+    ECR
+        *Work in Progress*
+
+    EF
+        *Work in Progress*
+
+    efi
+        *Work in Progress*
+
+    EFI
+        *Work in Progress*
+
+    el
+        *Work in Progress*
+
+    ELinks
+        *Work in Progress*
+
+    EMC
+        *Work in Progress*
+
+    Engenio
+        *Work in Progress*
+
+    eno
+        *Work in Progress*
+
+    enp
+        *Work in Progress*
+
+    enroll
+        *Work in Progress*
+
+    ensite
+        *Work in Progress*
+
+    EOL
+        *Work in Progress*
+
+    ERD
+        *Work in Progress*
+
+    ERDs
+        *Work in Progress*
+
+    ErrorDocument
+        *Work in Progress*
+
+    ErrorLog
+        *Work in Progress*
+
+    ESM
+        *Work in Progress*
+
+    ESXi
+        *Work in Progress*
+
+    etckeeper
+        *Work in Progress*
+
+    eth
+        *Work in Progress*
+
+    ETW
+        *Work in Progress*
+
+    etwlogs
+        *Work in Progress*
+
+    ExecCGI
+        *Work in Progress*
+
+    executables
+        *Work in Progress*
+
+    eXecution
+        *Work in Progress*
+
+    exim
+        *Work in Progress*
+
+    Exim
+        *Work in Progress*
+
+    exportfs
+        *Work in Progress*
+
+    extensibility
+        *Work in Progress*
+
+    failover
+        *Work in Progress*
+
+    fallbacks
+        *Work in Progress*
+
+    FastCGI
+        *Work in Progress*
+
+    favor
+        *Work in Progress*
+
+    favorite
+        *Work in Progress*
+
+    fb
+        *Work in Progress*
+
+    FC
+        *Work in Progress*
+
+    feistyduck
+        *Work in Progress*
+
+    FHS
+        *Work in Progress*
+
+    Fi
+        *Work in Progress*
+
+    filebug
+        *Work in Progress*
+
+    FileSet
+        *Work in Progress*
+
+    filesystem
+        *Work in Progress*
+
+    filesystems
+        *Work in Progress*
+
+    filesytem
+        *Work in Progress*
+
+    FIPS
+        *Work in Progress*
+
+    firefox
+        *Work in Progress*
+
+    firsttest
+        *Work in Progress*
+
+    fluentd
+        *Work in Progress*
+
+    Fluentd
+        *Work in Progress*
+
+    FQDN
+        *Work in Progress*
+
+    FQDN's
+        *Work in Progress*
+
+    Freedesktop
+        *Work in Progress*
+
+    FreeIPA
+        *Work in Progress*
+
+    freenode
+        *Work in Progress*
+
+    frontend
+        *Work in Progress*
+
+    frontends
+        *Work in Progress*
+
+    fsck
+        *Work in Progress*
+
+    fsync
+        *Work in Progress*
+
+    fulfill
+        *Work in Progress*
+
+    FULLTEXT
+        *Work in Progress*
+
+    FW
+        *Work in Progress*
+
+    gauranteed
+        *Work in Progress*
+
+    GCE
+        *Work in Progress*
+
+    GCM
+        *Work in Progress*
+
+    GCP
+        *Work in Progress*
+
+    gcplogs
+        *Work in Progress*
+
+    gcrypt
+        *Work in Progress*
+
+    GDB
+        *Work in Progress*
+
+    GDB's
+        *Work in Progress*
+
+    gelf
+        *Work in Progress*
+
+    Gentoo
+        *Work in Progress*
+
+    george
+        *Work in Progress*
+
+    getty
+        *Work in Progress*
+
+    gfs
+        *Work in Progress*
+
+    GFS
+        *Work in Progress*
+
+    GFS2
+        *Work in Progress*
+
+    GiB
+        *Work in Progress*
+
+    gid
+        *Work in Progress*
+
+    gids
+        *Work in Progress*
+
+    GIDs
+        *Work in Progress*
+
+    gitolite
+        *Work in Progress*
+
+    Gitolite's
+        *Work in Progress*
+
+    GKE
+        *Work in Progress*
+
+    GL
+        *Work in Progress*
+
+    GNU
+        *Work in Progress*
+
+    GnuTLS
+        *Work in Progress*
+
+    GPG
+        *Work in Progress*
+
+    GPL
+        *Work in Progress*
+
+    GPS
+        *Work in Progress*
+
+    gps
+        *Work in Progress*
+
+    GPSD
+        *Work in Progress*
+
+    gpsd
+        *Work in Progress*
+
+    GPUs
+        *Work in Progress*
+
+    Graber
+        *Work in Progress*
+
+    Graylog
+        *Work in Progress*
+
+    grubnetaa
+        *Work in Progress*
+
+    grubnetx
+        *Work in Progress*
+
+    GSSAPI
+        *Work in Progress*
+
+    GTK
+        *Work in Progress*
+
+    GUI
+        *Work in Progress*
+
+    GUIs
+        *Work in Progress*
+
+    GV
+        *Work in Progress*
+
+    GZIP
+        *Work in Progress*
+
+    HA
+        *Work in Progress*
+
+    HBAs
+        *Work in Progress*
+
+    Helman
+        *Work in Progress*
+
+    HMAC
+        *Work in Progress*
+
+    HMC
+        *Work in Progress*
+
+    hostgroup
+        *Work in Progress*
+
+    hostname
+        *Work in Progress*
+
+    hostnames
+        *Work in Progress*
+
+    HOTP
+        *Work in Progress*
+
+    hotplug
+        *Work in Progress*
+
+    hotplugging
+        *Work in Progress*
+
+    HOWTO
+        *Work in Progress*
+
+    HowTo
+        *Work in Progress*
+
+    hpb
+        *Work in Progress*
+
+    hpc
+        *Work in Progress*
+
+    HPC
+        *Work in Progress*
+
+    HSG
+        *Work in Progress*
+
+    HSV
+        *Work in Progress*
+
+    HTCP
+        *Work in Progress*
+
+    htm
+        *Work in Progress*
+
+    html
+        *Work in Progress*
+
+    http
+        *Work in Progress*
+
+    HTTP
+        *Work in Progress*
+
+    httpd
+        *Work in Progress*
+
+    https
+        *Work in Progress*
+
+    HTTPS
+        *Work in Progress*
+
+    hugepage
+        *Work in Progress*
+
+    hugepages
+        *Work in Progress*
+
+    hugepagesz
+        *Work in Progress*
+
+    HWE
+        *Work in Progress*
+
+    ICAO
+        *Work in Progress*
+
+    ICMP
+        *Work in Progress*
+
+    ICP
+        *Work in Progress*
+
+    IDENT
+        *Work in Progress*
+
+    IDentifier
+        *Work in Progress*
+
+    idmap
+        *Work in Progress*
+
+    IMAP
+        *Work in Progress*
+
+    IMAPS
+        *Work in Progress*
+
+    IncludesNOEXEC
+        *Work in Progress*
+
+    InetOrgPerson
+        *Work in Progress*
+
+    INI
+        *Work in Progress*
+
+    init
+        *Work in Progress*
+
+    initialiasation
+        *Work in Progress*
+
+    initialization
+        *Work in Progress*
+
+    initialize
+        *Work in Progress*
+
+    initiatorname
+        *Work in Progress*
+
+    initrd
+        *Work in Progress*
+
+    InnoDB
+        *Work in Progress*
+
+    installserver
+        *Work in Progress*
+
+    integrations
+        *Work in Progress*
+
+    Interprocess
+        *Work in Progress*
+
+    io
+        *Work in Progress*
+
+    IOMMU
+        *Work in Progress*
+
+    IoT
+        *Work in Progress*
+
+    ip
+        *Work in Progress*
+
+    IP
+        *Work in Progress*
+
+    IPaddr
+        *Work in Progress*
+
+    IPC
+        *Work in Progress*
+
+    IPL
+        *Work in Progress*
+
+    IPMI
+        *Work in Progress*
+
+    ipmilan
+        *Work in Progress*
+
+    ipmitool
+        *Work in Progress*
+
+    IPP
+        *Work in Progress*
+
+    IPs
+        *Work in Progress*
+
+    IPSec
+        *Work in Progress*
+
+    iptables
+        *Work in Progress*
+
+    IPTables
+        *Work in Progress*
+
+    IPv
+        *Work in Progress*
+
+    IPvlan
+        *Work in Progress*
+
+    IPVS
+        *Work in Progress*
+
+    IQN
+        *Work in Progress*
+
+    irqbalance
+        *Work in Progress*
+
+    isc
+        *Work in Progress*
+
+    ISC's
+        *Work in Progress*
+
+    iscsi
+        *Work in Progress*
+
+    iSCSI
+        *Work in Progress*
+
+    iscsid
+        *Work in Progress*
+
+    iSCSILogicalUnit
+        *Work in Progress*
+
+    iSCSITarget
+        *Work in Progress*
+
+    ised
+        *Work in Progress*
+
+    iso
+        *Work in Progress*
+
+    ISO
+        *Work in Progress*
+
+    ISOs
+        *Work in Progress*
+
+    ISP's
+        *Work in Progress*
+
+    ISPs
+        *Work in Progress*
+
+    Jammy's
+        *Work in Progress*
+
+    jitter
+        *Work in Progress*
+
+    joe
+        *Work in Progress*
+
+    journald
+        *Work in Progress*
+
+    journaled
+        *Work in Progress*
+
+    journaling
+        *Work in Progress*
+
+    JSON
+        *Work in Progress*
+
+    json
+        *Work in Progress*
+
+    KDC
+        *Work in Progress*
+
+    KDC's
+        *Work in Progress*
+
+    KDCs
+        *Work in Progress*
+
+    kea
+        *Work in Progress*
+
+    keepalive
+        *Work in Progress*
+
+    Keepalived
+        *Work in Progress*
+
+    Kerber
+        *Work in Progress*
+
+    Kerberized
+        *Work in Progress*
+
+    kerberos
+        *Work in Progress*
+
+    Kerberos
+        *Work in Progress*
+
+    kex
+        *Work in Progress*
+
+    kexec
+        *Work in Progress*
+
+    keypair
+        *Work in Progress*
+
+    keypairs
+        *Work in Progress*
+
+    keyring
+        *Work in Progress*
+
+    keysalt
+        *Work in Progress*
+
+    keyservers
+        *Work in Progress*
+
+    keytab
+        *Work in Progress*
+
+    Keytab
+        *Work in Progress*
+
+    Keytool
+        *Work in Progress*
+
+    kraxel
+        *Work in Progress*
+
+    Kudu
+        *Work in Progress*
+
+    KVM
+        *Work in Progress*
+
+    kvm
+        *Work in Progress*
+
+    LAN
+        *Work in Progress*
+
+    LANs
+        *Work in Progress*
+
+    largemem
+        *Work in Progress*
+
+    ldap
+        *Work in Progress*
+
+    LDAP
+        *Work in Progress*
+
+    LDAPS
+        *Work in Progress*
+
+    ldapscripts
+        *Work in Progress*
+
+    LDAPv
+        *Work in Progress*
+
+    LDAPv3
+        *Work in Progress*
+
+    LDIF
+        *Work in Progress*
+
+    lex
+        *Work in Progress*
+
+    lftp
+        *Work in Progress*
+
+    libera
+        *Work in Progress*
+
+    libvirt
+        *Work in Progress*
+
+    Libvirt
+        *Work in Progress*
+
+    libvirt's
+        *Work in Progress*
+
+    lifecycle
+        *Work in Progress*
+
+    Lifecycle
+        *Work in Progress*
+
+    lightervisor
+        *Work in Progress*
+
+    Lighttpd
+        *Work in Progress*
+
+    linux
+        *Work in Progress*
+
+    Linux-vserver
+        *Work in Progress*
+
+    linuxcontainers
+        *Work in Progress*
+
+    LinuxONE
+        *Work in Progress*
+
+    Linuxplatform
+        *Work in Progress*
+
+    Livepatch
+        *Work in Progress*
+
+    livepatching
+        *Work in Progress*
+
+    LMA
+        *Work in Progress*
+
+    loadbalanced
+        *Work in Progress*
+
+    Loadbalanced
+        *Work in Progress*
+
+    loadbalancing
+        *Work in Progress*
+
+    Loadbalancing
+        *Work in Progress*
+
+    LoadModule
+        *Work in Progress*
+
+    localhost
+        *Work in Progress*
+
+    localhost's
+        *Work in Progress*
+
+    LockFile
+        *Work in Progress*
+
+    lockfile
+        *Work in Progress*
+
+    logentries
+        *Work in Progress*
+
+    Logentries
+        *Work in Progress*
+
+    logfiles
+        *Work in Progress*
+
+    LogFormat
+        *Work in Progress*
+
+    LogLevel
+        *Work in Progress*
+
+    Logstash
+        *Work in Progress*
+
+    Logwatch
+        *Work in Progress*
+
+    Logwatch's
+        *Work in Progress*
+
+    lookaside
+        *Work in Progress*
+
+    lookup
+        *Work in Progress*
+
+    lookups
+        *Work in Progress*
+
+    loopback
+        *Work in Progress*
+
+    LPAR
+        *Work in Progress*
+
+    LSI
+        *Work in Progress*
+
+    lspci
+        *Work in Progress*
+
+    LU
+        *Work in Progress*
+
+    LUA
+        *Work in Progress*
+
+    LUN
+        *Work in Progress*
+
+    LUNs
+        *Work in Progress*
+
+    LUs
+        *Work in Progress*
+
+    LV
+        *Work in Progress*
+
+    lvm
+        *Work in Progress*
+
+    LVM
+        *Work in Progress*
+
+    lvmetad
+        *Work in Progress*
+
+    lvmlockd
+        *Work in Progress*
+
+    lxc
+        *Work in Progress*
+
+    LXC
+        *Work in Progress*
+
+    lxcpath
+        *Work in Progress*
+
+    lxd
+        *Work in Progress*
+
+    LXD
+        *Work in Progress*
+
+    MAAS
+        *Work in Progress*
+
+    macOS
+        *Work in Progress*
+
+    MacOS
+        *Work in Progress*
+
+    macvlan
+        *Work in Progress*
+
+    Macvlan
+        *Work in Progress*
+
+    Maildir
+        *Work in Progress*
+
+    maintainer's
+        *Work in Progress*
+
+    manpage
+        *Work in Progress*
+
+    manpages
+        *Work in Progress*
+
+    Mantic
+        *Work in Progress*
+
+    maskable
+        *Work in Progress*
+
+    maxphysaddr
+        *Work in Progress*
+
+    mbox
+        *Work in Progress*
+
+    MCE
+        *Work in Progress*
+
+    MDA
+        *Work in Progress*
+
+    mdev
+        *Work in Progress*
+
+    mdns
+        *Work in Progress*
+
+    metapackage
+        *Work in Progress*
+
+    METAR
+        *Work in Progress*
+
+    Metroclusters
+        *Work in Progress*
+
+    microk
+        *Work in Progress*
+
+    microservices
+        *Work in Progress*
+
+    MicroStack
+        *Work in Progress*
+
+    microVMs
+        *Work in Progress*
+
+    mitigations
+        *Work in Progress*
+
+    motd
+        *Work in Progress*
+
+    MOTD
+        *Work in Progress*
+
+    mountpoints
+        *Work in Progress*
+
+    mpath
+        *Work in Progress*
+
+    mpatha
+        *Work in Progress*
+
+    mpathb
+        *Work in Progress*
+
+    mpathc
+        *Work in Progress*
+
+    mpathd
+        *Work in Progress*
+
+    MSA
+        *Work in Progress*
+
+    MTA
+        *Work in Progress*
+
+    MTR
+        *Work in Progress*
+
+    MTU
+        *Work in Progress*
+
+    MUA
+        *Work in Progress*
+
+    MUAs
+        *Work in Progress*
+
+    multicast
+        *Work in Progress*
+
+    multipass
+        *Work in Progress*
+
+    Multipass
+        *Work in Progress*
+
+    multipath
+        *Work in Progress*
+
+    Multipath
+        *Work in Progress*
+
+    multipathd
+        *Work in Progress*
+
+    multipathed
+        *Work in Progress*
+
+    multipathing
+        *Work in Progress*
+
+    multipaths
+        *Work in Progress*
+
+    Multiview
+        *Work in Progress*
+
+    Multiviews
+        *Work in Progress*
+
+    multiviews
+        *Work in Progress*
+
+    munin
+        *Work in Progress*
+
+    Munin
+        *Work in Progress*
+
+    MYDOMAIN
+        *Work in Progress*
+
+    mydomain
+        *Work in Progress*
+
+    MyISAM
+        *Work in Progress*
+
+    mynewsite
+        *Work in Progress*
+
+    mySQL
+        *Work in Progress*
+
+    mysql
+        *Work in Progress*
+
+    MySQL
+        *Work in Progress*
+
+    nagios
+        *Work in Progress*
+
+    Nagios
+        *Work in Progress*
+
+    nagiosadmin
+        *Work in Progress*
+
+    nameserver
+        *Work in Progress*
+
+    nameserver's
+        *Work in Progress*
+
+    nameservers
+        *Work in Progress*
+
+    namespace
+        *Work in Progress*
+
+    namespaced
+        *Work in Progress*
+
+    NAS
+        *Work in Progress*
+
+    NAT
+        *Work in Progress*
+
+    nat
+        *Work in Progress*
+
+    NATed
+        *Work in Progress*
+
+    natively
+        *Work in Progress*
+
+    Navisys
+        *Work in Progress*
+
+    NetApp
+        *Work in Progress*
+
+    netbios
+        *Work in Progress*
+
+    netboot
+        *Work in Progress*
+
+    Netboot
+        *Work in Progress*
+
+    netbooting
+        *Work in Progress*
+
+    Netfilter
+        *Work in Progress*
+
+    netlogon
+        *Work in Progress*
+
+    netmask
+        *Work in Progress*
+
+    netplan
+        *Work in Progress*
+
+    Netplan
+        *Work in Progress*
+
+    networkd
+        *Work in Progress*
+
+    newsfeeds
+        *Work in Progress*
+
+    nfs
+        *Work in Progress*
+
+    NFS
+        *Work in Progress*
+
+    NFSv
+        *Work in Progress*
+
+    NFV
+        *Work in Progress*
+
+    nginx
+        *Work in Progress*
+
+    Nginx
+        *Work in Progress*
+
+    nginx's
+        *Work in Progress*
+
+    NIC
+        *Work in Progress*
+
+    NICs
+        *Work in Progress*
+
+    Nield
+        *Work in Progress*
+
+    NIS
+        *Work in Progress*
+
+    NMI
+        *Work in Progress*
+
+    noanonymous
+        *Work in Progress*
+
+    nologin
+        *Work in Progress*
+
+    noplaintext
+        *Work in Progress*
+
+    notfound
+        *Work in Progress*
+
+    NRPE
+        *Work in Progress*
+
+    NSCQ
+        *Work in Progress*
+
+    NSS
+        *Work in Progress*
+
+    ntp
+        *Work in Progress*
+
+    NTP
+        *Work in Progress*
+
+    NTS
+        *Work in Progress*
+
+    NUMA
+        *Work in Progress*
+
+    Numa
+        *Work in Progress*
+
+    Numbat
+        *Work in Progress*
+
+    Nvidia
+        *Work in Progress*
+
+    Nvidia's
+        *Work in Progress*
+
+    NVMe
+        *Work in Progress*
+
+    NVRAM
+        *Work in Progress*
+
+    NVswitch
+        *Work in Progress*
+
+    NVSwitch
+        *Work in Progress*
+
+    O'Reilly
+        *Work in Progress*
+
+    O'Reilly's
+        *Work in Progress*
+
+    ocf
+        *Work in Progress*
+
+    OCF
+        *Work in Progress*
+
+    ocfs
+        *Work in Progress*
+
+    OCFS
+        *Work in Progress*
+
+    OCFS2
+        *Work in Progress*
+
+    OCI
+        *Work in Progress*
+
+    OCSP
+        *Work in Progress*
+
+    offical
+        *Work in Progress*
+
+    ok
+        *Work in Progress*
+
+    Ok
+        *Work in Progress*
+
+    onwards
+        *Work in Progress*
+
+    OpenLDAP
+        *Work in Progress*
+
+    opensc
+        *Work in Progress*
+
+    OpenSSH
+        *Work in Progress*
+
+    openssl
+        *Work in Progress*
+
+    OpenSSL
+        *Work in Progress*
+
+    OpenSSL's
+        *Work in Progress*
+
+    OpenStack
+        *Work in Progress*
+
+    openstack
+        *Work in Progress*
+
+    OpenSUSE
+        *Work in Progress*
+
+    openvpn
+        *Work in Progress*
+
+    OpenVPN
+        *Work in Progress*
+
+    OpenVPN's
+        *Work in Progress*
+
+    OpenVswitch
+        *Work in Progress*
+
+    openvswitch
+        *Work in Progress*
+
+    OpenVZ
+        *Work in Progress*
+
+    OpenWRT
+        *Work in Progress*
+
+    ordinated
+        *Work in Progress*
+
+    organization
+        *Work in Progress*
+
+    organizations
+        *Work in Progress*
+
+    organize
+        *Work in Progress*
+
+    OSA
+        *Work in Progress*
+
+    OSI
+        *Work in Progress*
+
+    ote
+        *Work in Progress*
+
+    OTP
+        *Work in Progress*
+
+    overlayfs
+        *Work in Progress*
+
+    OverlayFS
+        *Work in Progress*
+
+    OVS
+        *Work in Progress*
+
+    OvS
+        *Work in Progress*
+
+    Packt's
+        *Work in Progress*
+
+    pam
+        *Work in Progress*
+
+    parm
+        *Work in Progress*
+
+    parmfile
+        *Work in Progress*
+
+    passcodes
+        *Work in Progress*
+
+    passthrough
+        *Work in Progress*
+
+    PATHs
+        *Work in Progress*
+
+    pb
+        *Work in Progress*
+
+    PCI
+        *Work in Progress*
+
+    PCIe
+        *Work in Progress*
+
+    pcs
+        *Work in Progress*
+
+    PDC
+        *Work in Progress*
+
+    pdc
+        *Work in Progress*
+
+    PDFs
+        *Work in Progress*
+
+    PEM
+        *Work in Progress*
+
+    Petitboot
+        *Work in Progress*
+
+    petitboot
+        *Work in Progress*
+
+    PgSQL
+        *Work in Progress*
+
+    php
+        *Work in Progress*
+
+    phpMyAdmin
+        *Work in Progress*
+
+    PID
+        *Work in Progress*
+
+    pid
+        *Work in Progress*
+
+    PidFile
+        *Work in Progress*
+
+    pingable
+        *Work in Progress*
+
+    PIV
+        *Work in Progress*
+
+    PKCS
+        *Work in Progress*
+
+    PKI
+        *Work in Progress*
+
+    PKINIT
+        *Work in Progress*
+
+    pluggable
+        *Work in Progress*
+
+    PMD
+        *Work in Progress*
+
+    PMDs
+        *Work in Progress*
+
+    POSIX
+        *Work in Progress*
+
+    Postcopy
+        *Work in Progress*
+
+    postfix
+        *Work in Progress*
+
+    Postfix
+        *Work in Progress*
+
+    Postgres
+        *Work in Progress*
+
+    PostScript
+        *Work in Progress*
+
+    PowerShell
+        *Work in Progress*
+
+    Powershell
+        *Work in Progress*
+
+    PPA
+        *Work in Progress*
+
+    PPAs
+        *Work in Progress*
+
+    ppc
+        *Work in Progress*
+
+    PPD
+        *Work in Progress*
+
+    Preboot
+        *Work in Progress*
+
+    prepended
+        *Work in Progress*
+
+    preseed
+        *Work in Progress*
+
+    PreSharedKey
+        *Work in Progress*
+
+    PrivateKey
+        *Work in Progress*
+
+    procfs
+        *Work in Progress*
+
+    proxied
+        *Work in Progress*
+
+    proxying
+        *Work in Progress*
+
+    PTP
+        *Work in Progress*
+
+    PTR
+        *Work in Progress*
+
+    pty
+        *Work in Progress*
+
+    PubkeyAuthentication
+        *Work in Progress*
+
+    PXE
+        *Work in Progress*
+
+    PXELINUX
+        *Work in Progress*
+
+    qa
+        *Work in Progress*
+
+    qdevice
+        *Work in Progress*
+
+    Qdevice
+        *Work in Progress*
+
+    QEMU
+        *Work in Progress*
+
+    qeth
+        *Work in Progress*
+
+    quickstart
+        *Work in Progress*
+
+    rangesize
+        *Work in Progress*
+
+    rclone
+        *Work in Progress*
+
+    RDAC
+        *Work in Progress*
+
+    RDBMS
+        *Work in Progress*
+
+    rdn
+        *Work in Progress*
+
+    RDN
+        *Work in Progress*
+
+    recognize
+        *Work in Progress*
+
+    recognized
+        *Work in Progress*
+
+    recognizes
+        *Work in Progress*
+
+    Redbook
+        *Work in Progress*
+
+    refered
+        *Work in Progress*
+
+    renderer
+        *Work in Progress*
+
+    repos
+        *Work in Progress*
+
+    resolv
+        *Work in Progress*
+
+    REXX
+        *Work in Progress*
+
+    RFC
+        *Work in Progress*
+
+    rid
+        *Work in Progress*
+
+    riscv
+        *Work in Progress*
+
+    ROCKs
+        *Work in Progress*
+
+    rocks
+        *Work in Progress*
+
+    ROMs
+        *Work in Progress*
+
+    rootDN
+        *Work in Progress*
+
+    RootDN
+        *Work in Progress*
+
+    rootfs
+        *Work in Progress*
+
+    routable
+        *Work in Progress*
+
+    RSA
+        *Work in Progress*
+
+    rsnapshot
+        *Work in Progress*
+
+    rsync
+        *Work in Progress*
+
+    rsyslog
+        *Work in Progress*
+
+    rsyslog's
+        *Work in Progress*
+
+    RTC
+        *Work in Progress*
+
+    runtime
+        *Work in Progress*
+
+    runtimes
+        *Work in Progress*
+
+    SAN
+        *Work in Progress*
+
+    sandboxed
+        *Work in Progress*
+
+    SANLOCK
+        *Work in Progress*
+
+    SANs
+        *Work in Progress*
+
+    SANtricity
+        *Work in Progress*
+
+    sasl
+        *Work in Progress*
+
+    SASL
+        *Work in Progress*
+
+    sbd
+        *Work in Progress*
+
+    SBD
+        *Work in Progress*
+
+    sbin
+        *Work in Progress*
+
+    scalability
+        *Work in Progress*
+
+    scalable
+        *Work in Progress*
+
+    schemas
+        *Work in Progress*
+
+    SCP
+        *Work in Progress*
+
+    Scrollback
+        *Work in Progress*
+
+    scrollback
+        *Work in Progress*
+
+    scsi
+        *Work in Progress*
+
+    SCSI
+        *Work in Progress*
+
+    sdc
+        *Work in Progress*
+
+    sdd
+        *Work in Progress*
+
+    sde
+        *Work in Progress*
+
+    sdf
+        *Work in Progress*
+
+    sdh
+        *Work in Progress*
+
+    sdj
+        *Work in Progress*
+
+    SDN
+        *Work in Progress*
+
+    sdX
+        *Work in Progress*
+
+    seccomp
+        *Work in Progress*
+
+    SECLEVEL
+        *Work in Progress*
+
+    sendmail
+        *Work in Progress*
+
+    ServerAdmin
+        *Work in Progress*
+
+    ServerAlias
+        *Work in Progress*
+
+    ServerName
+        *Work in Progress*
+
+    SFTP
+        *Work in Progress*
+
+    sg
+        *Work in Progress*
+
+    SGI
+        *Work in Progress*
+
+    SHA
+        *Work in Progress*
+
+    shadowLastChange
+        *Work in Progress*
+
+    sharding
+        *Work in Progress*
+
+    ShareAlike
+        *Work in Progress*
+
+    SHell
+        *Work in Progress*
+
+    SHM
+        *Work in Progress*
+
+    Shorewall
+        *Work in Progress*
+
+    SIDs
+        *Work in Progress*
+
+    signaling
+        *Work in Progress*
+
+    SIMD
+        *Work in Progress*
+
+    slapd
+        *Work in Progress*
+
+    slapo
+        *Work in Progress*
+
+    SLiRP
+        *Work in Progress*
+
+    smartcard
+        *Work in Progress*
+
+    SMB
+        *Work in Progress*
+
+    smbldap
+        *Work in Progress*
+
+    SMS
+        *Work in Progress*
+
+    SMTP
+        *Work in Progress*
+
+    SMTPS
+        *Work in Progress*
+
+    sn
+        *Work in Progress*
+
+    Snap
+        *Work in Progress*
+
+    Snap'ed
+        *Work in Progress*
+
+    snapd
+        *Work in Progress*
+
+    snapshotted
+        *Work in Progress*
+
+    snapshotting
+        *Work in Progress*
+
+    snapstore
+        *Work in Progress*
+
+    Snapstore
+        *Work in Progress*
+
+    SNMP
+        *Work in Progress*
+
+    SOA
+        *Work in Progress*
+
+    Solaris
+        *Work in Progress*
+
+    sos
+        *Work in Progress*
+
+    SPC
+        *Work in Progress*
+
+    splunk
+        *Work in Progress*
+
+    Splunk
+        *Work in Progress*
+
+    SRU
+        *Work in Progress*
+
+    srv
+        *Work in Progress*
+
+    ss
+        *Work in Progress*
+
+    SSD
+        *Work in Progress*
+
+    SSD's
+        *Work in Progress*
+
+    SSH
+        *Work in Progress*
+
+    sshd
+        *Work in Progress*
+
+    sshkeygen
+        *Work in Progress*
+
+    SSI
+        *Work in Progress*
+
+    SSL
+        *Work in Progress*
+
+    ssl
+        *Work in Progress*
+
+    SSLCertificateFile
+        *Work in Progress*
+
+    SSLCertificateKeyFile
+        *Work in Progress*
+
+    SSO
+        *Work in Progress*
+
+    sss
+        *Work in Progress*
+
+    sssd
+        *Work in Progress*
+
+    SSSD
+        *Work in Progress*
+
+    SSSD's
+        *Work in Progress*
+
+    StartTLS
+        *Work in Progress*
+
+    stateful
+        *Work in Progress*
+
+    STDIN
+        *Work in Progress*
+
+    STDOUT
+        *Work in Progress*
+
+    Stephane
+        *Work in Progress*
+
+    STK
+        *Work in Progress*
+
+    stonith
+        *Work in Progress*
+
+    storages
+        *Work in Progress*
+
+    su
+        *Work in Progress*
+
+    subcommand
+        *Work in Progress*
+
+    Subiquity
+        *Work in Progress*
+
+    subnet
+        *Work in Progress*
+
+    subnetwork
+        *Work in Progress*
+
+    Subquity
+        *Work in Progress*
+
+    substring
+        *Work in Progress*
+
+    subuid
+        *Work in Progress*
+
+    subvolume
+        *Work in Progress*
+
+    sudo
+        *Work in Progress*
+
+    summarize
+        *Work in Progress*
+
+    superblock
+        *Work in Progress*
+
+    suxxif
+        *Work in Progress*
+
+    symlink
+        *Work in Progress*
+
+    symlinked
+        *Work in Progress*
+
+    symlinks
+        *Work in Progress*
+
+    SymLinksIfOwnerMatch
+        *Work in Progress*
+
+    synchronize
+        *Work in Progress*
+
+    synchronized
+        *Work in Progress*
+
+    syncprov
+        *Work in Progress*
+
+    syncrepl
+        *Work in Progress*
+
+    syncronises
+        *Work in Progress*
+
+    sysctls
+        *Work in Progress*
+
+    sysinfo
+        *Work in Progress*
+
+    syslog
+        *Work in Progress*
+
+    systemctl
+        *Work in Progress*
+
+    systemd
+        *Work in Progress*
+
+    Systemd
+        *Work in Progress*
+
+    Systemd's
+        *Work in Progress*
+
+    targetcli
+        *Work in Progress*
+
+    Tasksel
+        *Work in Progress*
+
+    TCP
+        *Work in Progress*
+
+    tdb
+        *Work in Progress*
+
+    Telegraf
+        *Work in Progress*
+
+    Telegraf's
+        *Work in Progress*
+
+    templated
+        *Work in Progress*
+
+    TFTP
+        *Work in Progress*
+
+    TGS
+        *Work in Progress*
+
+    tgt
+        *Work in Progress*
+
+    TGT
+        *Work in Progress*
+
+    th
+        *Work in Progress*
+
+    thinpool
+        *Work in Progress*
+
+    timedatectl
+        *Work in Progress*
+
+    timesyncd
+        *Work in Progress*
+
+    TLB
+        *Work in Progress*
+
+    TLS
+        *Work in Progress*
+
+    TLSv
+        *Work in Progress*
+
+    tmpfs
+        *Work in Progress*
+
+    Tmpfs
+        *Work in Progress*
+
+    tmux
+        *Work in Progress*
+
+    topologies
+        *Work in Progress*
+
+    TOTP
+        *Work in Progress*
+
+    traceback
+        *Work in Progress*
+
+    Traceroute
+        *Work in Progress*
+
+    tradeoff
+        *Work in Progress*
+
+    triagers
+        *Work in Progress*
+
+    ttys
+        *Work in Progress*
+
+    tunable
+        *Work in Progress*
+
+    tunables
+        *Work in Progress*
+
+    TuneD
+        *Work in Progress*
+
+    tunings
+        *Work in Progress*
+
+    Tunnelblick
+        *Work in Progress*
+
+    tunneling
+        *Work in Progress*
+
+    TXT
+        *Work in Progress*
+
+    ubuntu
+        *Work in Progress*
+
+    Ubuntu
+        *Work in Progress*
+
+    UDA
+        *Work in Progress*
+
+    udev
+        *Work in Progress*
+
+    UDP
+        *Work in Progress*
+
+    UEFI
+        *Work in Progress*
+
+    UEFI's
+        *Work in Progress*
+
+    ufw
+        *Work in Progress*
+
+    uid
+        *Work in Progress*
+
+    UID
+        *Work in Progress*
+
+    uids
+        *Work in Progress*
+
+    UIDs
+        *Work in Progress*
+
+    UIs
+        *Work in Progress*
+
+    umounts
+        *Work in Progress*
+
+    un
+        *Work in Progress*
+
+    unassign
+        *Work in Progress*
+
+    Unassign
+        *Work in Progress*
+
+    unassigning
+        *Work in Progress*
+
+    uncomment
+        *Work in Progress*
+
+    uncommented
+        *Work in Progress*
+
+    uncommenting
+        *Work in Progress*
+
+    unencrypted
+        *Work in Progress*
+
+    unicast
+        *Work in Progress*
+
+    Unix98
+        *Work in Progress*
+
+    unmount
+        *Work in Progress*
+
+    unmounts
+        *Work in Progress*
+
+    untrusted
+        *Work in Progress*
+
+    upgraders
+        *Work in Progress*
+
+    uptime
+        *Work in Progress*
+
+    URI
+        *Work in Progress*
+
+    URIs
+        *Work in Progress*
+
+    useradd
+        *Work in Progress*
+
+    userid
+        *Work in Progress*
+
+    userland
+        *Work in Progress*
+
+    usermode
+        *Work in Progress*
+
+    userPassword
+        *Work in Progress*
+
+    userspace
+        *Work in Progress*
+
+    USN
+        *Work in Progress*
+
+    usr
+        *Work in Progress*
+
+    util
+        *Work in Progress*
+
+    utils
+        *Work in Progress*
+
+    UUIDs
+        *Work in Progress*
+
+    UUIDS
+        *Work in Progress*
+
+    uvtool
+        *Work in Progress*
+
+    UVTool
+        *Work in Progress*
+
+    UVtool
+        *Work in Progress*
+
+    Valgrind
+        *Work in Progress*
+
+    vCPUs
+        *Work in Progress*
+
+    VCS
+        *Work in Progress*
+
+    veth
+        *Work in Progress*
+
+    VFIO
+        *Work in Progress*
+
+    vfio
+        *Work in Progress*
+
+    VFS
+        *Work in Progress*
+
+    VFs
+        *Work in Progress*
+
+    VG
+        *Work in Progress*
+
+    vGPU
+        *Work in Progress*
+
+    vincent
+        *Work in Progress*
+
+    virgil
+        *Work in Progress*
+
+    virsh
+        *Work in Progress*
+
+    virt
+        *Work in Progress*
+
+    VirtIO
+        *Work in Progress*
+
+    virtiofs
+        *Work in Progress*
+
+    VirtualHost
+        *Work in Progress*
+
+    virtualise
+        *Work in Progress*
+
+    Virtualised
+        *Work in Progress*
+
+    virtualised
+        *Work in Progress*
+
+    virtualiser
+        *Work in Progress*
+
+    virtualization
+        *Work in Progress*
+
+    virtualizations
+        *Work in Progress*
+
+    virtualize
+        *Work in Progress*
+
+    virtualizing
+        *Work in Progress*
+
+    VLAN
+        *Work in Progress*
+
+    VM's
+        *Work in Progress*
+
+    VMs
+        *Work in Progress*
+
+    VMWare
+        *Work in Progress*
+
+    VMware
+        *Work in Progress*
+
+    VNC
+        *Work in Progress*
+
+    VNX
+        *Work in Progress*
+
+    vpn
+        *Work in Progress*
+
+    VPN
+        *Work in Progress*
+
+    VPNs
+        *Work in Progress*
+
+    VRRP
+        *Work in Progress*
+
+    vserver
+        *Work in Progress*
+
+    vsftpd
+        *Work in Progress*
+
+    vSwitch
+        *Work in Progress*
+
+    Vswitch
+        *Work in Progress*
+
+    WAL
+        *Work in Progress*
+
+    WAN
+        *Work in Progress*
+
+    WANs
+        *Work in Progress*
+
+    wbinfo
+        *Work in Progress*
+
+    WCCP
+        *Work in Progress*
+
+    weatherutility
+        *Work in Progress*
+
+    Webserver
+        *Work in Progress*
+
+    webserver
+        *Work in Progress*
+
+    wg
+        *Work in Progress*
+
+    Wi
+        *Work in Progress*
+
+    winbind
+        *Work in Progress*
+
+    Wireguard
+        *Work in Progress*
+
+    WireGuard
+        *Work in Progress*
+
+    WLAN
+        *Work in Progress*
+
+    Wordpress
+        *Work in Progress*
+
+    workgroup
+        *Work in Progress*
+
+    WSGI
+        *Work in Progress*
+
+    WWID
+        *Work in Progress*
+
+    WWIDs
+        *Work in Progress*
+
+    www
+        *Work in Progress*
+
+    wxWidgets
+        *Work in Progress*
+
+    Xen
+        *Work in Progress*
+
+    Xenial
+        *Work in Progress*
+
+    xhtml
+        *Work in Progress*
+
+    XLOG
+        *Work in Progress*
+
+    xml
+        *Work in Progress*
+
+    yaml
+        *Work in Progress*
+
+    YAML
+        *Work in Progress*
+
+    Yubikey
+        *Work in Progress*
+
+    yyyymmddss
+        *Work in Progress*
+
+    zFCP
+        *Work in Progress*
+
+    ZFS
+        *Work in Progress*
+
+    zfs
+        *Work in Progress*
+
+    zpool
+        *Work in Progress*
+
+    Zytrax's
+        *Work in Progress*

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -59,3 +59,4 @@ Other tools
     backups.rst
     debugging.rst
     other-tools.rst
+    glossary.rst


### PR DESCRIPTION
This pull request solves issue #5 by creating a glossary page for the Ubuntu Server Documentation.

## Changes

1. Created a Glossary Page:
  - Added a new glossary.rst file in the reference directory.
  - Populated the glossary with terms from the `.custom_wordlist.txt` file, leaving definitions as placeholders (*Work in Progress*) for future updates.

2. Tested the functionality by referencing the term `ACLs` in the `/openldap/access-control.md` file to ensure it links correctly to the glossary.

3. Updated the index.rst file to include the glossary in the documentation structure.

4. Added a warning banner to the glossary page to indicate that it is a work in progress and invite contributions.