### PR TITLE
Fix spacing in glossary

### DIFF
--- a/reference/glossary.rst
+++ b/reference/glossary.rst
@@ -120,6 +120,7 @@ Glossary
 
     bootloader
         *Work in Progress*
+
     bootp
         *Work in Progress*
 
@@ -767,6 +768,7 @@ Glossary
 
     ISC's
         *Work in Progress*
+
     iSCSI
         *Work in Progress*
 


### PR DESCRIPTION
### Description

Missing some empty lines, which throws errors on local docs builds

---

### Related Issue

N/A

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.