### PR TITLE
Exclude PR template from Sphinx processing

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -200,6 +200,7 @@ custom_excludes = [
     'doc-cheat-sheet*',
     'readme.rst',
     'legacy/*.md',
+    '.github/pull_request_template.md',
 ]
 
 # Allow Sphinx to use both rst and md


### PR DESCRIPTION
### Description

Local builds of the docs are given warnings as Sphinx tries to process the pull request template (.md) file. Adding the file to the excludes list will make Sphinx ignore it.

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.