### PR TITLE
Add new contributions to contributing page

### DIFF
--- a/contributing/contributors.md
+++ b/contributing/contributors.md
@@ -7,8 +7,9 @@ sections below (organised alphabetically), there is a huge variety of fixes,
 content updates and improvements being made across the Ubuntu Server
 documentation. The most recently submitted PRs are at the top of each table.
 
-This documentation exists because of the efforts of everyone who has taken the
-time to create, maintain and improve it. Thank you to all of you!
+This documentation is a testament to the valued efforts of our community
+members who have invested their time in its creation, maintenance and
+improvement.
 
 ## Content updates
 

--- a/contributing/contributors.md
+++ b/contributing/contributors.md
@@ -1,0 +1,167 @@
+(contributors)=
+
+# Our contributors
+
+Curious about what our contributors have been doing? As you can see from the
+sections below (organised alphabetically), there is a huge variety of fixes,
+content updates and improvements being made across the Ubuntu Server
+documentation. The most recently submitted PRs are at the top of each table.
+
+This documentation exists because of the efforts of everyone who has taken the
+time to create, maintain and improve it. Thank you to all of you!
+
+## Content updates
+
+```{list-table}
+:header-rows: 1
+
+* - PR number
+  - Contributed by
+  - Contribution made
+
+* - [PR #130](https://github.com/canonical/ubuntu-server-documentation/pull/130)
+  - `Sophie-Pages`
+  - Deprecated the `lxc-containers.md` page
+
+* - [PR #119](https://github.com/canonical/ubuntu-server-documentation/pull/119)
+  - `Sophie-Pages`
+  - Added introduction to `install-openldap.md` page
+
+* - [PR #115](https://github.com/canonical/ubuntu-server-documentation/pull/115)
+  - `minaelee`
+  - Updated and refreshed content on `lxd-containers.md` page
+
+* - [PR #113](https://github.com/canonical/ubuntu-server-documentation/pull/130)
+  - `teward`
+  - Updated `apparmor.md` to explain how to totally enable/disable AppArmor
+
+* - [PR #54](https://github.com/canonical/ubuntu-server-documentation/pull/54)
+  - `khbecker`
+  - Added details about kdump enablement in 24.10 to `kernel-crash-dump.md`
+```
+
+## Copyediting and proofreading
+
+```{list-table}
+:header-rows: 1
+
+* - PR number
+  - Contributed by
+  - Contribution made
+
+* - [PR #141](https://github.com/canonical/ubuntu-server-documentation/pull/141)
+  - `gregbell`
+  - Improved the `qemu-microvm.md` page
+
+* - [PR #132](https://github.com/canonical/ubuntu-server-documentation/pull/132)
+  - `birdstare`
+  - Substantial copyediting on the `networking.md` page
+
+* - [PR #131](https://github.com/canonical/ubuntu-server-documentation/pull/131)
+  - `network-charles`
+  - Improved the `ebpf.md` page
+
+* - [PR #123](https://github.com/canonical/ubuntu-server-documentation/pull/123)
+  - `davidekete`
+  - Converted "note" blocks into MyST admonitions (explanation section)
+
+* - [PR #122](https://github.com/canonical/ubuntu-server-documentation/pull/122)
+  - `YanisaHS`
+  - Improved the `install-dns.md` page
+
+* - [PR #120](https://github.com/canonical/ubuntu-server-documentation/pull/120)
+  - `davidekete`
+  - Converted "note" blocks into MyST admonitions (reference section)
+
+* - [PR #83](https://github.com/canonical/ubuntu-server-documentation/pull/83)
+  - `daveedoo`
+  - Improved the `serve-ntp-with-chrony.md` page
+
+* - [PR #81](https://github.com/canonical/ubuntu-server-documentation/pull/81)
+  - `peat-psuwit`
+  - Improved the `report-a-bug.md` page
+
+* - [PR #67](https://github.com/canonical/ubuntu-server-documentation/pull/67)
+  - `pnhuy`
+  - Improved the `configur-nginx.md` page
+```
+
+## Error fixes
+
+```{list-table}
+:header-rows: 1
+
+* - PR number
+  - Contributed by
+  - Contribution made
+
+* - [PR #97](https://github.com/canonical/ubuntu-server-documentation/pull/97)
+  - `yukihane`
+  - Corrected an error in `install-openvpn.md`
+
+* - [PR #66](https://github.com/canonical/ubuntu-server-documentation/pull/66)
+  - `Pexers`
+  - Removed duplicate text block in `peer-to-site-on-router.md`
+
+* - [PR #52](https://github.com/canonical/ubuntu-server-documentation/pull/52)
+  - `sbworth`
+  - Corrected an error in WireGuard VPN `on-an-internal-system.md`
+
+* - [PR #48](https://github.com/canonical/ubuntu-server-documentation/pull/48)
+  - `nikolas`
+  - Corrected an error in `install-postfix.md`
+```
+
+## GitHub repository
+
+```{list-table}
+:header-rows: 1
+
+* - PR number
+  - Contributed by
+  - Contribution made
+
+* - [PR #116](https://github.com/canonical/ubuntu-server-documentation/pull/116)
+  - `activus-d`
+  - Created an issue template to help readers provide better feedback
+
+* - [PR #112](https://github.com/canonical/ubuntu-server-documentation/pull/112)
+  - `goodylili`
+  - Created a pull request template
+```
+
+## Glossary
+
+```{list-table}
+:header-rows: 1
+
+* - PR number
+  - Contributed by
+  - Contribution made
+
+* - [PR #134](https://github.com/canonical/ubuntu-server-documentation/pull/134)
+  - `RomainDusi`
+  - Contributed terms to the glossary
+
+* - [PR #124](https://github.com/canonical/ubuntu-server-documentation/pull/124)
+  - `activus-d`
+  - Added the glossary page and functionality
+```
+
+## PDF improvements
+
+```{list-table}
+:header-rows: 1
+
+* - PR number
+  - Contributed by
+  - Contribution made
+
+* - [PR #10](https://github.com/canonical/ubuntu-server-documentation/pull/10)
+  - `SecondSkoll`
+  - Added the ability to build the PDF locally
+
+* - [PR #9](https://github.com/canonical/ubuntu-server-documentation/pull/9)
+  - `SecondSkoll`
+  - Fixed our PDF build issues
+```

--- a/contributing/index.rst
+++ b/contributing/index.rst
@@ -101,14 +101,7 @@ Lastly, we would like to thank you for spending your time to help make the
 Ubuntu Server documentation better. Every step in the right direction is a step
 worth taking, no matter how large or small.
 
-Our contributors
-----------------
-
-Thanks to **SecondSkoll**, who has styled our PDF and added the ability to
-build it locally:
-
-* PR: `Fix PDF build issues <https://github.com/canonical/ubuntu-server-documentation/pull/9>`_
-* PR: `Adds entrypoint for local PDF generation <https://github.com/canonical/ubuntu-server-documentation/pull/10>`_
+Check out what :ref:`our contributors <contributors>` have been working on!
 
 .. toctree::
    :maxdepth: 1
@@ -121,6 +114,7 @@ build it locally:
    writing-guidance.rst
    submit-contribution.rst
    get-help.rst
+   contributors
 
 .. LINKS
 .. _Code of Conduct: https://ubuntu.com/community/ethos/code-of-conduct


### PR DESCRIPTION
### Description

Our contributors list was last updated last year, so it was time for a refresh.

I have created a new contributors page and added all our contributors and their contributions to it, grouped by the varied types of contributions being made. 

*Please do not merge immediately* as I'm planning to solicit feedback on the layout and content before merging. If it is approved, I will aim to update the page every month.

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
