### PR TITLE
Change html to markdown in header

### DIFF
--- a/how-to/graphics/install-nvidia-drivers.md
+++ b/how-to/graphics/install-nvidia-drivers.md
@@ -104,9 +104,7 @@ sudo apt install nvidia-fabricmanager-535 libnvidia-nscq-535
 > **Note**:
 > While `nvidia-fabricmanager` and `libnvidia-nscq` do not have the same `-server` label in their name, they are really meant to match the `-server` drivers in the Ubuntu archive. For example, `nvidia-fabricmanager-535` will match the `nvidia-driver-535-server` package version (not the `nvidia-driver-535 package`).
 
-<h2 id="heading--manual-driver-installation-using-apt">
-Manual driver installation (using APT)
-</h2>
+## Manual driver installation (using APT)
 
 Installing the NVIDIA driver manually means installing the correct kernel modules first, then installing the metapackage for the driver series.
 


### PR DESCRIPTION
### Description

This was left in the docs from the old Discourse page, and was causing the header not to show up in the navigation. Corrected the header to be in markdown.

---

### Related Issue

- Fixes: #150 

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Commit Message for Squash Merge

We typically squash commits when merging. You can specify the commit message that should be used in this case if you wish.
Provide the desired commit message below:

[(optional) category] Brief description of changes made, and why

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
