### PR TITLE
NTS can use pools

### DIFF
--- a/how-to/networking/serve-ntp-with-chrony.md
+++ b/how-to/networking/serve-ntp-with-chrony.md
@@ -351,10 +351,12 @@ For more complex scenarios there are many more advanced options for configuring 
 
 ### NTS client
 
-The client needs to specify `server` as usual (`pool` directives do not work with NTS). Afterwards, the server address options can be listed and it is there that `nts` can be added. For example:
+The client needs to specify `server` or `pool` as usual. Afterwards, the options can be listed and it is there that `nts` can be added. For example:
 
 ```text
 server <server-fqdn-or-IP> iburst nts
+# or as concrete example
+pool 1.ntp.ubuntu.com iburst maxsources 1 nts prefer
 ```
 
 One can check the `authdata` of the connections established by the client using `sudo chronyc -N authdata`, which will provide the following information:


### PR DESCRIPTION
Andreas and IS have found how to set this up and work when providing ubuntu NTS servers. Hence the client description needs to be updated.

### Checklist

- [+] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [+] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [N/A] My pull request is linked to an existing issue (if applicable).
- [+] I have tested my changes, and they work as expected.