### PR TITLE
Mismatch between image and docs

### DIFF
--- a/how-to/wireguard-vpn/on-an-internal-system.md
+++ b/how-to/wireguard-vpn/on-an-internal-system.md
@@ -9,7 +9,7 @@ To recap, our home network has the `10.10.10.0/24` address, and we want to conne
 
 ```
                        public internet
-10.10.10.3/24
+10.10.10.11/24
         home0│            xxxxxx       ppp0 ┌────────┐
            ┌─┴──┐         xx   xxxxx  ──────┤ router │
            │    ├─ppp0  xxx       xx        └───┬────┘    home network, .home domain
@@ -110,7 +110,7 @@ $ sudo wg-quick up wg0
 
 The peer configuration will be very similar to what was done before. What changes will be the address, since now it won't be on an exclusive network for the VPN, but will have an address carved out of the home network block.
 
-Let's call this new configuration file `/etc/wireguard/home_internal.conf`:
+Let's call this new configuration file `/etc/wireguard/home0.conf`:
 
 ```
 [Interface]
@@ -127,7 +127,7 @@ AllowedIPs = 10.10.10.0/24
 And bring up this WireGuard interface:
 
 ```bash
-$ sudo wg-quick up home_internal
+$ sudo wg-quick up home0
 ```
 
 > **Note**:

--- a/how-to/wireguard-vpn/on-an-internal-system.md
+++ b/how-to/wireguard-vpn/on-an-internal-system.md
@@ -22,7 +22,7 @@ To recap, our home network has the `10.10.10.0/24` address, and we want to conne
                                                   │   │     │   │     │   │
                                                   └───┘     └───┘     └───┘
 Reserved for VPN users:
-10.10.10.2-9
+10.10.10.10-49
 ```
 
 ## Router changes


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Description
There is a mismatch between the "image" (ok, ascii-art) and the docs. This PR makes them match again.

### Related Issue
- Fixes: #61 

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)
I only did not address the comment that says `10.10.10.11/24`  should instead be `10.10.10.11/32`. I remember this being important when I was testing the setup, and must have settled on `/24`. The route to `10.10.10.0/24` will be added by `AllowedIPs = 10.10.10.0/24` anyway. If the submitter could double check this (that `/32` can/should be used in the `Address` parameter of the `home0.conf` file), that would be great. Otherwise I'll try to find some time to set this up again.
