### PR TITLE
Fix broken links to CODA's using git guide

### DIFF
--- a/contributing/build-locally.rst
+++ b/contributing/build-locally.rst
@@ -110,4 +110,4 @@ Once you have made your changes and are happy with them, you can
 :ref:`find out how to submit them <submit-work>`.
 
 .. _Diátaxis: https://diataxis.fr/
-.. _working with git: https://github.com/canonical/open-documentation-academy/blob/main/getting-started/using_git.md
+.. _working with git: https://canonical-coda.readthedocs-hosted.com/en/latest/docs/howto/get-started/using_git/

--- a/contributing/submit-contribution.rst
+++ b/contributing/submit-contribution.rst
@@ -141,6 +141,6 @@ Once the discussion has concluded, and you have made any agreed changes, the PR
 will be approved and then merged. Congratulations (and thank you)! You are now
 an open source contributor!
 
-.. _getting started with git: https://github.com/canonical/open-documentation-academy/blob/main/getting-started/using_git.md
+.. _getting started with git: https://canonical-coda.readthedocs-hosted.com/en/latest/docs/howto/get-started/using_git/
 .. _Create a Pull Request: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
 .. _Link your pull request to your issue: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue


### PR DESCRIPTION
### Description

Fixes a broken link to CODA docs site's [Using git guide](https://canonical-coda.readthedocs-hosted.com/en/latest/docs/howto/get-started/using_git/) in two places. The original git guide document was moved in the source to `https://github.com/canonical/open-documentation-academy/blob/main/website/docs/howto/get-started/using_git.md`. It can now be viewed in its rendered form at the new link, on [the new CODA site on RTD](https://canonical-coda.readthedocs-hosted.com/). 🥳  

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---
