### PR TITLE
Add hoverxref extension

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -170,6 +170,7 @@ custom_extensions = [
     'sphinxcontrib.jquery',
     'sphinxcontrib.mermaid',
     'sphinxext.rediraffe',
+    'hoverxref.extension',
 #    'canonical.youtube-links',
 #    'canonical.related-links',
 #    'canonical.custom-rst-roles',
@@ -187,7 +188,14 @@ custom_extensions = [
 custom_required_modules = [
     'sphinxcontrib-mermaid',
     'sphinxext-rediraffe',
+    'sphinx-hoverxref',
 ]
+
+# Configure hoverxref options
+hoverxref_role_types = {
+    'term': 'tooltip',
+}
+hoverxref_roles = ['term',]
 
 # Add redirects, so they can be updated here to land with docs being moved
 rediraffe_branch = "main"


### PR DESCRIPTION

### Description

This PR adds a hoverxref extension to enable hovering over the terms specified in the glossary.

### Related Issue

- Fixes: #126

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
