### PR TITLE
Update the makefile and build-locally page

### DIFF
--- a/Makefile.sp
+++ b/Makefile.sp
@@ -11,6 +11,8 @@ BUILDDIR      = _build
 VENVDIR       = $(SPHINXDIR)/venv
 PA11Y         = $(SPHINXDIR)/node_modules/pa11y/bin/pa11y.js --config $(SPHINXDIR)/pa11y.json
 VENV          = $(VENVDIR)/bin/activate
+SPHINX_HOST     ?= 127.0.0.1
+SPHINX_PORT     ?= 8000
 
 .PHONY: sp-full-help sp-woke-install sp-pa11y-install sp-install sp-run sp-html \
         sp-epub sp-serve sp-clean sp-clean-doc sp-spelling sp-linkcheck sp-woke \
@@ -54,7 +56,7 @@ sp-install: $(VENVDIR)
 	command -v distro-info || (sudo apt-get update; sudo apt-get install --assume-yes distro-info)
 
 sp-run: sp-install
-	. $(VENV); sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	. $(VENV); sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 sp-html: sp-install

--- a/contributing/build-locally.rst
+++ b/contributing/build-locally.rst
@@ -89,7 +89,7 @@ browser. To resolve this, add the export variable to your shell by running the f
 
    export SPHINX_HOST=0.0.0.0
 
-Running the `make run` command should then work as expected.
+Running the ``make run`` command should then work as expected.
 
 .. note::
    If you have problems getting the documentation to run on your machine,

--- a/contributing/build-locally.rst
+++ b/contributing/build-locally.rst
@@ -82,13 +82,14 @@ It will watch the folder, and whenever you save changes to a file, this URL
 will give update the preview to show your changes (or warn you if something has
 gone horribly wrong!).
 
-If you are building locally on an Ubuntu Cloud VM or a container, you may experience issues accessing the page from a browser. To 
-resolve this, include ``--host 0.0.0.0`` in the ``sp-run`` section of the ``Makefile.sp`` file.
+If you are building locally on an Ubuntu Cloud VM or a container, you may experience issues accessing the page from your host's 
+browser. To resolve this, add the export variable to your shell by running the following command:
 
 .. code-block::
 
-   sp-run: sp-install
-	. $(VENV); sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) --host 0.0.0.0
+   export SPHINX_HOST=0.0.0.0
+
+Running the `make run` command should then work as expected.
 
 .. note::
    If you have problems getting the documentation to run on your machine,


### PR DESCRIPTION
### Description

The upstream Canonical/sphinx-docs-starter-pack#353 has been updated with new changes to the makefile. It gives contributors the option to define which host IP address to bind.

I've updated these changes to this makefile. I also added the extra action needed if the contributor executes a `make run` command inside a container or Cloud VM.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.