### PR TITLE
Virtualisation architecture overhaul part 2

### DIFF
--- a/how-to/virtualisation/cloud-image-vms-with-uvtool.md
+++ b/how-to/virtualisation/cloud-image-vms-with-uvtool.md
@@ -137,8 +137,9 @@ Once you are finished with your VM, you can destroy it with:
 uvt-kvm destroy secondtest
 ```
 
-> **Note**:
-   Unlike libvirt's `destroy` or `undefine` actions, this will (by default) also remove the associated virtual storage files.
+```{note}
+Unlike libvirt's `destroy` or `undefine` actions, this will (by default) also remove the associated virtual storage files.
+```
 
 ## More `uvt-kvm` options
 

--- a/how-to/virtualisation/enable-nested-virtualisation.md
+++ b/how-to/virtualisation/enable-nested-virtualisation.md
@@ -1,8 +1,9 @@
 (enable-nested-virtualisation)=
 # How to enable nested virtualisation
 
-> **Disclaimer**:
-> Nested virtualisation is enabled by default on Ubuntu. If you are using Ubuntu, it's unlikely that you will need to manually enable the feature. If you check (using the steps below) and discover that nested virtualisation is enabled, then you will not need to do anything further.
+```{important}
+Nested virtualisation is enabled by default on Ubuntu. If you are using Ubuntu, it's unlikely that you will need to manually enable the feature. If you check (using the steps below) and discover that nested virtualisation is enabled, then you will not need to do anything further.
+```
 
 There may be use cases where you need to enable nested virtualisation so that you can deploy instances inside other instances. The sections below explain how to check if nested virtualisation is enabled/available and how to enable it if that is not the case. Bear in mind that currently nested virtualisation is only supported in Ubuntu on `x86` machine architecture. 
 
@@ -35,7 +36,7 @@ If the output is either `1` or `Y` then nested virtualisation is enabled and you
 
 ### If the module is not loaded
 
-If the module your host requires is not loaded you can load it using `modprobe` and add the property `nested=1` to enable nested virtualisation as shown below for Intel hosts:
+If the module your host requires is not loaded, you can load it using `modprobe` in combination with the property `nested=1` to enable nested virtualisation, as shown below for Intel hosts:
 
 ```bash
 modprobe kvm-intel nested=1
@@ -47,36 +48,35 @@ Or as follows for AMD hosts:
 modprobe kvm-amd nested=1
 ```
 
-
 ## Enable nested virtualisation 
 
 If the above checks indicate that nested virtualisation is not enabled, you can follow the below steps to enable it.
 
-  * Create a file in `/etc/modprobe.d` -e.g., `/etc/modprobe.d/kvm.conf`- and add the line `options kvm-intel nested=1` to that file (replace `kvm-intel` with `kvm-amd` for AMD hosts).
+* Create a file in `/etc/modprobe.d` -e.g., `/etc/modprobe.d/kvm.conf`- and add the line `options kvm-intel nested=1` to that file (replace `kvm-intel` with `kvm-amd` for AMD hosts).
 
-  * Reload the kernel module to apply the changes:
+* Reload the kernel module to apply the changes:
 
-  ```bash
-    sudo modprobe -r <module>
-  ```
+```bash
+  sudo modprobe -r <module>
+```
 
-  Example for Intel hosts:
+Example for Intel hosts:
 
-  ```bash
-    sudo modprobe -r kvm-intel
-  ```
+```bash
+  sudo modprobe -r kvm-intel
+```
 
-  * You should now be able to see nested virtualisation enabled:
+* You should now be able to see nested virtualisation enabled:
 
-  Example for Intel hosts:
-  ```bash
-    $ cat /sys/module/kvm_intel/parameters/nested
-    Y
-  ```
+Example for Intel hosts:
+```bash
+  $ cat /sys/module/kvm_intel/parameters/nested
+  Y
+```
 
 ## Check and enable nested virtualisation inside an instance
 
-Once the host is ready to use nested virtualisation it is time to check if the guest instance where the other instance(s) are going to run is able to host these nested VMs. 
+Once the host is ready to use nested virtualisation, it is time to check if the guest instance can run additional nested VMs inside it.
 
 To determine if an instance can host another instance on top, run the below command within the instance:
 
@@ -86,16 +86,18 @@ egrep "svm|vmx" /proc/cpuinfo
 
 If any of these are present in the output (depending on whether the host is AMD or Intel respectively), then virtualisation is available in that instance. If this is not the case you will need to edit the instance CPU settings:
 
-  * Shut down the instance
-  * Edit the instance XML definition file executing: `virsh edit <instance>`
-  * Search the `cpu mode` parameter in and set its value to either `host-model` or `host-passthrough` (details about these modes can be found [here](https://wiki.openstack.org/wiki/LibvirtXMLCPUModel)).
+* Shut down the instance
+* Edit the instance XML definition file executing: `virsh edit <instance>`
+* Search the `cpu mode` parameter in and set its value to either `host-model` or `host-passthrough` (details about these modes can be found [here](https://wiki.openstack.org/wiki/LibvirtXMLCPUModel)).
 
-    Sample `cpu mode` parameter in XML with nested virtualisation: 
-    ```xml
-      <cpu mode='host-model' check='partial'/>
-    ```
-  * Save the modifications and start the instance
+  Sample `cpu mode` parameter in XML with nested virtualisation:
+
+  ```xml
+    <cpu mode='host-model' check='partial'/>
+  ```
+  
+* Save the modifications and start the instance
 
 ## Limitations of nested virtualisation
 
-Nested virtualisation has some key limitations you'd need to consider. Namely, not all KVM features will be available for instances running nested VMs and actions such as migrating or saving the parent instance will not be possible until the nested instance is stopped.
+Nested virtualisation has some key limitations you'd need to consider, namely that not all KVM features will be available for instances running nested VMs, and actions such as migrating or saving the parent instance will not be possible until the nested instance is stopped.

--- a/how-to/virtualisation/libvirt.md
+++ b/how-to/virtualisation/libvirt.md
@@ -1,7 +1,6 @@
 (libvirt)=
 # Libvirt
 
-
 The [libvirt library](https://libvirt.org/) is used to interface with many different virtualisation technologies. Before getting started with libvirt it is best to make sure your hardware supports the necessary virtualisation extensions for [Kernel-based Virtual Machine (KVM)](https://www.linux-kvm.org/page/Main_Page). To check this, enter the following from a terminal prompt:
 
 ```bash
@@ -10,14 +9,15 @@ kvm-ok
 
 A message will be printed informing you if your CPU *does* or *does not* support hardware virtualisation.
 
-> **Note**:
-> On many computers with processors supporting hardware-assisted virtualisation, it is necessary to first activate an option in the BIOS to enable it.
+```{note}
+On many computers with processors supporting hardware-assisted virtualisation, it is necessary to first activate an option in the BIOS to enable it.
+```
 
 ## Virtual networking
 
 There are a few different ways to allow a virtual machine access to the external network. The default virtual network configuration includes **bridging** and **iptables** rules implementing **usermode** networking, which uses the [SLiRP](https://en.wikipedia.org/wiki/Slirp) protocol. Traffic is NATed through the host interface to the outside network.
 
-To enable external hosts to directly access services on virtual machines a different type of *bridge* than the default needs to be configured. This allows the virtual interfaces to connect to the outside network through the physical interface, making them appear as normal hosts to the rest of the network.
+To enable external hosts to directly access services on virtual machines, a different type of *bridge* than the default needs to be configured. This allows the virtual interfaces to connect to the outside network through the physical interface, making them appear as normal hosts to the rest of the network.
 
 There is a great example of [how to configure a bridge](https://netplan.readthedocs.io/en/latest/netplan-yaml/#properties-for-device-type-bridges) and combine it with libvirt so that guests will use it at the [netplan.io documentation](https://netplan.readthedocs.io/en/latest/).
 
@@ -38,8 +38,9 @@ In a terminal enter:
 sudo adduser $USER libvirt
 ```
 
-> **Note**:
-> If the chosen user is the current user, you will need to log out and back in for the new group membership to take effect.
+```{note}
+If the chosen user is the current user, you will need to log out and back in for the new group membership to take effect.
+```
 
 You are now ready to install a *Guest* operating system. Installing a virtual machine follows the same process as installing the operating system directly on the hardware.
 
@@ -83,7 +84,7 @@ There are several utilities available to manage virtual machines and libvirt. Th
   ```
 
 - Reboot a virtual machine with:
-  
+
   ```bash
   virsh reboot <guestname>
   ```
@@ -124,8 +125,9 @@ This will allow you to edit the [XML representation that defines the guest](http
 
 Editing the XML directly certainly is the most powerful way, but also the most complex one. Tools like {ref}`Virtual Machine Manager / Viewer <virtual-machine-manager>` can help inexperienced users to do most of the common tasks.
 
-> **Note**:
-> If `virsh` (or other `vir*` tools) connect to something other than the default `qemu-kvm`/system hypervisor, one can find alternatives for the `--connect` option using `man virsh` or the [libvirt docs](http://libvirt.org/uri.html).
+```{note}
+If `virsh` (or other `vir*` tools) connect to something other than the default `qemu-kvm`/system hypervisor, one can find alternatives for the `--connect` option using `man virsh` or the [libvirt docs](http://libvirt.org/uri.html).
+```
 
 ### `system` and `session` scope
 
@@ -137,8 +139,8 @@ virsh --connect qemu:///system
 
 There are two options for the connection.
 
-  * `qemu:///system` - connect locally as **root** to the daemon supervising QEMU and KVM domains
-  * `qemu:///session` - connect locally as a **normal user** to their own set of QEMU and KVM domains
+* `qemu:///system` - connect locally as **root** to the daemon supervising QEMU and KVM domains
+* `qemu:///session` - connect locally as a **normal user** to their own set of QEMU and KVM domains
 
 The *default* was always (and still is) `qemu:///system` as that is the behavior most users are accustomed to. But there are a few benefits (and drawbacks) to `qemu:///session` to consider.
 
@@ -158,31 +160,31 @@ Applications will usually decide on their primary use-case. Desktop-centric appl
 
 There are different types of migration available depending on the versions of libvirt and the hypervisor being used. In general those types are:
 
-  - [Offline migration](https://libvirt.org/migration.html#offline)
+- [Offline migration](https://libvirt.org/migration.html#offline)
 
-  - [Live migration](https://libvirt.org/migration.html)
+- [Live migration](https://libvirt.org/migration.html)
 
-  - [Postcopy migration](http://wiki.qemu.org/Features/PostCopyLiveMigration)
+- [Postcopy migration](http://wiki.qemu.org/Features/PostCopyLiveMigration)
 
 There are various options to those methods, but the entry point for all of them is `virsh migrate`. Read the integrated help for more detail.
 
 ```bash
- virsh migrate --help 
+ virsh migrate --help
 ```
 
 Some useful documentation on the constraints and considerations of live migration can be found at the [Ubuntu Wiki](https://wiki.ubuntu.com/QemuKVMMigration).
 
 ## Device passthrough/hotplug
 
-If, rather than the hotplugging described here, you want to always pass through a device then add the XML content of the device to your static guest XML representation via `virsh edit <guestname>`. In that case you won't need to use *attach/detach*. There are different kinds of passthrough. Types available to you depend on your hardware and software setup.
+If you want to always pass through a device rather than using the hotplugging method described here, add the XML content of the device to your static guest XML representation via `virsh edit <guestname>`. In that case, you won't need to use *attach/detach*. There are different kinds of passthrough, and the types available to you depend on your hardware and software setup.
 
-  - USB hotplug/passthrough
+- USB hotplug/passthrough
 
-  - VF hotplug/Passthrough
+- VF hotplug/Passthrough
 
-Both kinds are handled in a very similar way and while there are various way to do it (e.g. also via QEMU monitor) driving such a change via libvirt is recommended. That way, libvirt can try to manage all sorts of special cases for you and also somewhat masks version differences.
+Both kinds are handled in a very similar way and while there are various way to do it (e.g. also via QEMU monitor), driving such a change via libvirt is recommended. That way, libvirt can try to manage all sorts of special cases for you and also somewhat masks version differences.
 
-In general when driving hotplug via libvirt you create an XML snippet that describes the device just as you would do in a static [guest description](https://libvirt.org/formatdomain.html). A USB device is usually identified by vendor/product ID:
+In general, when driving hotplug via libvirt, you create an XML snippet that describes the device just as you would do in a static [guest description](https://libvirt.org/formatdomain.html). A USB device is usually identified by vendor/product ID:
 
 ```xml
 <hostdev mode='subsystem' type='usb' managed='yes'>
@@ -193,7 +195,7 @@ In general when driving hotplug via libvirt you create an XML snippet that descr
 </hostdev>
 ```
 
-Virtual functions are usually assigned via their PCI ID (domain, bus, slot, function).
+Virtual functions are usually assigned via their PCI ID (domain, bus, slot, and function).
 
 ```xml
 <hostdev mode='subsystem' type='pci' managed='yes'>
@@ -203,18 +205,21 @@ Virtual functions are usually assigned via their PCI ID (domain, bus, slot, func
 </hostdev>
 ```
 
-> **Note**:
-> To get the virtual function in the first place is very device dependent and can therefore not be fully covered here. But in general it involves setting up an IOMMU, registering via [VFIO](https://www.kernel.org/doc/Documentation/vfio.txt) and sometimes requesting a number of VFs. Here an example on ppc64el to get 4 VFs on a device:
-> 
-> ```bash
-> $ sudo modprobe vfio-pci
-> # identify device
-> $ lspci -n -s 0005:01:01.3
-> 0005:01:01.3 0200: 10df:e228 (rev 10)
-> # register and request VFs
-> $ echo 10df e228 | sudo tee /sys/bus/pci/drivers/vfio-pci/new_id
-> $ echo 4 | sudo tee /sys/bus/pci/devices/0005\:01\:00.0/sriov_numvfs
-> ```
+```{note}
+Getting the virtual function in the first place is very device-dependent and can, therefore, not be fully covered here. But in general, it involves setting up an {term}`IOMMU`, registering via [VFIO](https://www.kernel.org/doc/Documentation/vfio.txt) and sometimes requesting a number of VFs.
+```
+
+Here is an example of configuring a [ppc64el](https://wiki.debian.org/ppc64el) system to create four VFs on a device:
+
+```bash
+$ sudo modprobe vfio-pci
+# identify device
+$ lspci -n -s 0005:01:01.3
+0005:01:01.3 0200: 10df:e228 (rev 10)
+# register and request VFs
+$ echo 10df e228 | sudo tee /sys/bus/pci/drivers/vfio-pci/new_id
+$ echo 4 | sudo tee /sys/bus/pci/devices/0005\:01\:00.0/sriov_numvfs
+```
 
 You then attach or detach the device via libvirt by relating the guest with the XML snippet.
 
@@ -233,7 +238,8 @@ Libvirt covers most use cases needed, but if you ever want/need to work around l
 ```bash
 virsh qemu-monitor-command --hmp focal-test-log 'drive_add 0 if=none,file=/var/lib/libvirt/images/test.img,format=raw,id=disk1'
 ```
-But since the monitor is so powerful, you can do a lot -- especially for debugging purposes like showing the guest registers:
+
+But since the monitor is so powerful, you can do a lot -- especially for debugging purposes, like showing the guest registers:
 
 ```bash
 virsh qemu-monitor-command --hmp y-ipns 'info registers'
@@ -244,16 +250,16 @@ RSI=0000000000000000 RDI=ffff8f0fdd5c7e48 RBP=ffff8f0f5d5c7e18 RSP=ffff8f0f5d5c7
 
 ## Huge pages
 
-Using huge pages can help to reduce TLB pressure, page table overhead and speed up some further memory relate actions. Furthermore by default [transparent huge pages](https://www.kernel.org/doc/Documentation/vm/transhuge.txt) are useful, but can be quite some overhead - so if it is clear that using huge pages is preferred then making them explicit usually has some gains.
+Using huge pages can help to reduce TLB pressure, page table overhead, and speed up some further memory relate actions. Furthermore by default [transparent huge pages](https://www.kernel.org/doc/Documentation/vm/transhuge.txt) are useful, but can be quite some overhead - so if it is clear that using huge pages is preferred then making them explicit usually has some gains.
 
-While huge page are admittedly harder to manage (especially later in the system's lifetime if memory is fragmented) they provide a useful boost especially for rather large guests.
+While huge pages are admittedly harder to manage (especially later in the system's lifetime if memory is fragmented), they provide a useful boost, especially for rather large guests.
 
 > **Bonus**:
-> When using device passthrough on very large guests there is an extra benefit of using huge pages as it is faster to do the initial memory clear on VFIO {term}`DMA` pin.
+> When using device passthrough on very large guests, there is an extra benefit of using huge pages, as it is faster to do the initial memory clear on the VFIO {term}`DMA` pin.
 
 ### Huge page allocation
 
-Huge pages come in different sizes. A *normal* page is usually 4k and huge pages are either 2M or 1G, but depending on the architecture other options are possible.
+Huge pages come in different sizes. A *normal* page is usually 4k and huge pages are either 2M or 1G, but depending on the architecture, other options are possible.
 
 The simplest yet least reliable way to allocate some huge pages is to just echo a value to `sysfs`:
 
@@ -269,7 +275,7 @@ cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
 256
 ```
 
-There one of these sizes is "default huge page size" which will be used in the auto-mounted `/dev/hugepages`. Changing the default size requires a reboot and is set via [default_hugepagesz](https://www.kernel.org/doc/html/v5.4/admin-guide/kernel-parameters.html).
+There one of these sizes is the "default huge page size", which will be used in the auto-mounted `/dev/hugepages`. Changing the default size requires a reboot and is set via [default_hugepagesz](https://www.kernel.org/doc/html/v5.4/admin-guide/kernel-parameters.html).
 
 You can check the current default size:
 
@@ -282,7 +288,7 @@ Hugepagesize:       2048 kB
 But there can be more than one at the same time -- so it's a good idea to check:
 
 ```bash
-$ tail /sys/kernel/mm/hugepages/hugepages-*/nr_hugepages` 
+$ tail /sys/kernel/mm/hugepages/hugepages-*/nr_hugepages`
 ==> /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages <==
 0
 ==> /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages <==
@@ -293,7 +299,7 @@ And even that could -- on bigger systems -- be further split per [Numa node](htt
 
 One can allocate huge pages at [boot or runtime](https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt), but due to fragmentation there are no guarantees it works later. The [kernel documentation](https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt) lists details on both ways.
 
-Huge pages need to be allocated by the kernel as mentioned above but to be consumable they also have to be mounted. By default, `systemd` will make `/dev/hugepages` available for the default huge page size.
+Huge pages need to be allocated by the kernel as mentioned above, but to be consumable, they also have to be mounted. By default, `systemd` will make `/dev/hugepages` available for the default huge page size.
 
 Feel free to add more mount points if you need different sized ones. An overview can be queried with:
 
@@ -325,15 +331,15 @@ For more control, e.g. how memory is spread over [Numa nodes](https://www.kernel
 
 ## Controlling addressing bits
 
-This is a topic that rarely matters on a single computer with virtual machines for generic use; libvirt will automatically use the hypervisor default, which in the case of QEMU is 40 bits. This default aims for compatibility since it will be the same on all systems, which simplifies migration between them and usually is compatible even with older hardware. 
+This is a topic that rarely matters on a single computer with virtual machines for generic use; libvirt will automatically use the hypervisor default, which in the case of QEMU is 40 bits. This default aims for compatibility since it will be the same on all systems, which simplifies migration between them and usually is compatible even with older hardware.
 
 However, it can be very important when driving more advanced use cases. If one needs bigger guest sizes with more than a terabyte of memory then controlling the addressing bits is crucial.
 
 ### -hpb machine types
 
-Since Ubuntu 18.04 the QEMU in Ubuntu has [provided special machine-types](https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1776189). These have been the Ubuntu machine type like `pc-q35-jammy` or `pc-i440fx-jammy` but with a `-hpb` suffix. The “hpb” abbreviation stands for “host-physical-bits”, which is the QEMU option that this represents.
+Since Ubuntu 18.04, the QEMU in Ubuntu has [provided special machine-types](https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1776189). These include machine types like `pc-q35-jammy` or `pc-i440fx-jammy`, but with a `-hpb` suffix. The “hpb” abbreviation stands for “host-physical-bits”, which is the QEMU option that this represents.
 
-For example, by using `pc-q35-jammy-hpb` the guest would use the number of physical bits that the Host CPU has available.
+For example, by using `pc-q35-jammy-hpb`, the guest would use the number of physical bits that the Host CPU has available.
 
 Providing the configuration that a guest should use more address bits as a machine type has the benefit that many higher level management stacks like for example openstack, are already able to control it through libvirt.
 
@@ -348,19 +354,19 @@ address sizes   : 46 bits physical, 48 bits virtual
 address sizes   : 39 bits physical, 48 bits virtual
 ```
 
-
 ### maxphysaddr guest configuration
 
-Since libvirt version 8.7.0 (>= Ubuntu 22.10 Lunar), `maxphysaddr` can be controlled via the [CPU model and topology section](https://libvirt.org/formatdomain.html#cpu-model-and-topology) of the guest configuration. 
+Since libvirt version 8.7.0 (>= Ubuntu 22.10 Lunar), `maxphysaddr` can be controlled via the [CPU model and topology section](https://libvirt.org/formatdomain.html#cpu-model-and-topology) of the guest configuration.
 If one needs just a large guest, like before when using the `-hpb` types, all that is needed is the following libvirt guest xml configuration:
 
 ```xml
   <maxphysaddr mode='passthrough' />
 ```
 
-Since libvirt 9.2.0 and 9.3.0 (>= Ubuntu 23.10 Mantic), an explicit number of emulated bits or a limit to the passthrough can be specified. Combined, this pairing can be very useful for computing clusters where the CPUs have different hardware physical addressing bits. Without these features guests could be large, but potentially unable to migrate freely between all nodes since not all systems would support the same amount of addressing bits.
+Since libvirt 9.2.0 and 9.3.0 (>= Ubuntu 23.10 Mantic), an explicit number of emulated bits or a limit to the passthrough can be specified. Combined, this pairing can be very useful for computing clusters where the CPUs have different hardware physical addressing 
+bits. Without these features, guests could be large, but potentially unable to migrate freely between all nodes since not all systems would support the same amount of addressing bits.
 
-But now, one can either set a fix value of addressing bits:
+But now, one can either set a fixed value of addressing bits:
 
 ```xml
   <maxphysaddr mode='emulate' bits='42'/>
@@ -372,15 +378,14 @@ Or use the best available by a given hardware, without going over a certain limi
   <maxphysaddr mode='passthrough' limit='41/>
 ```
 
-
 ## AppArmor isolation
 
-By default libvirt will spawn QEMU guests using AppArmor isolation for enhanced security. The [AppArmor rules for a guest](https://gitlab.com/apparmor/apparmor/-/wikis/Libvirt#implementation-overview) will consist of multiple elements:
+By default, libvirt will spawn QEMU guests using AppArmor isolation for enhanced security. The [AppArmor rules for a guest](https://gitlab.com/apparmor/apparmor/-/wikis/Libvirt#implementation-overview) will consist of multiple elements:
 
 - A static part that all guests share => `/etc/apparmor.d/abstractions/libvirt-qemu`
 - A dynamic part created at guest start time and modified on hotplug/unplug => `/etc/apparmor.d/libvirt/libvirt-f9533e35-6b63-45f5-96be-7cccc9696d5e.files`
 
-Of the above, the former is provided and updated by the `libvirt-daemon` package and the latter is generated on guest start. Neither of the two should be manually edited. They will, by default, cover the vast majority of use cases and work fine. But there are certain cases where users either want to:
+Of the above, the former is provided and updated by the `libvirt-daemon` package, and the latter is generated on guest start. Neither of the two should be manually edited. They will, by default, cover the vast majority of use cases and work fine. But there are certain cases where users either want to:
 
 - Further lock down the guest, e.g. by explicitly denying access that usually would be allowed.
 - Open up the guest isolation. Most of the time this is needed if the setup on the local machine does not follow the commonly used paths.
@@ -392,7 +397,7 @@ To do so there are two files. Both are local overrides which allow you to modify
 - `/etc/apparmor.d/local/usr.lib.libvirt.virt-aa-helper`
   The above-mentioned *dynamic part* that is individual per guest is generated by a tool called `libvirt.virt-aa-helper`. That is under AppArmor isolation as well. This is most commonly used if you want to use uncommon paths as it allows one to have those uncommon paths in the [guest XML](https://libvirt.org/formatdomain.html) (see `virsh edit`) and have those paths rendered to the per-guest dynamic rules.
 
-## Sharing files between Host<->Guest 
+## Sharing files between Host<->Guest
 
 To be able to exchange data, the memory of the guest has to be allocated as "shared". To do so you need to add the following to the guest config:
 
@@ -414,7 +419,7 @@ is recommended to use huge pages which then would look like:
 </memoryBacking>
 ```
 
-In the guest definition one then can add `filesystem` sections to specify host paths to share with the guest. The *target dir* is a bit special as it isn't really a directory -- instead it is a *tag* that in the guest can be used to access this particular `virtiofs` instance.
+In the guest definition, one then can add `filesystem` sections to specify host paths to share with the guest. The *target dir* is a bit special as it isn't really a directory -- instead, it is a *tag* that in the guest can be used to access this particular `virtiofs` instance.
 
 ```xml
 <filesystem type='mount' accessmode='passthrough'>
@@ -424,13 +429,13 @@ In the guest definition one then can add `filesystem` sections to specify host p
 </filesystem>
 ```
 
-And in the guest this can now be used based on the tag `myfs` like:
+And in the guest, this can now be used based on the tag `myfs` like:
 
 ```bash
 sudo mount -t virtiofs myfs /mnt/
 ```
 
-Compared to other Host/Guest file sharing options -- commonly Samba, NFS or 9P -- `virtiofs` is usually much faster and also more compatible with usual file system semantics.
+Compared to other Host/Guest file sharing options -- commonly Samba, NFS, or 9P -- `virtiofs` is usually much faster and also more compatible with usual file system semantics.
 
 See the [libvirt domain/filesystem](https://libvirt.org/formatdomain.html#filesystems) documentation for further details on these.
 
@@ -439,12 +444,12 @@ See the [libvirt domain/filesystem](https://libvirt.org/formatdomain.html#filesy
 
 ## Resources
 
-  - See the [KVM home page](http://www.linux-kvm.org/) for more details.
+- See the [KVM home page](http://www.linux-kvm.org/) for more details.
 
-  - For more information on libvirt see the [libvirt home page](http://libvirt.org/).
+- For more information on libvirt see the [libvirt home page](http://libvirt.org/).
 
-    - XML configuration of [domains](https://libvirt.org/formatdomain.html) and [storage](https://libvirt.org/formatstorage.html) are the most often used libvirt reference.
+  - XML configuration of [domains](https://libvirt.org/formatdomain.html) and [storage](https://libvirt.org/formatstorage.html) are the most often used libvirt reference.
 
-  - Another good resource is the [Ubuntu Wiki KVM](https://help.ubuntu.com/community/KVM) page.
+- Another good resource is the [Ubuntu Wiki KVM](https://help.ubuntu.com/community/KVM) page.
 
-  - For basics on how to assign VT-d devices to QEMU/KVM, please see the [linux-kvm](http://www.linux-kvm.org/page/How_to_assign_devices_with_VT-d_in_KVM#Assigning_the_device) page.
+- For basics on how to assign VT-d devices to QEMU/KVM, please see the [linux-kvm](http://www.linux-kvm.org/page/How_to_assign_devices_with_VT-d_in_KVM#Assigning_the_device) page.

--- a/how-to/virtualisation/libvirt.md
+++ b/how-to/virtualisation/libvirt.md
@@ -54,7 +54,7 @@ In the case of virtual machines, a {term}`Graphical User Interface (GUI) <GUI>` 
 
 ## Virtual machine management
 
-The following section covers the command-line tools around `virsh` that are part of libvirt itself. But there are various options at different levels of complexities and feature-sets, like:
+The following section covers `virsh`, a virtual machine management tool that is a part of libvirt. But there are other tools available at different levels of complexities and feature-sets, like:
 
 * {ref}`Multipass <create-vms-with-multipass>
 * {ref}`UVTool <cloud-image-vms-with-uvtool>`
@@ -242,7 +242,8 @@ virsh qemu-monitor-command --hmp focal-test-log 'drive_add 0 if=none,file=/var/l
 But since the monitor is so powerful, you can do a lot -- especially for debugging purposes, like showing the guest registers:
 
 ```bash
-virsh qemu-monitor-command --hmp y-ipns 'info registers'
+$ virsh qemu-monitor-command --hmp y-ipns 'info registers'
+
 RAX=00ffffc000000000 RBX=ffff8f0f5d5c7e48 RCX=0000000000000000 RDX=ffffea00007571c0
 RSI=0000000000000000 RDI=ffff8f0fdd5c7e48 RBP=ffff8f0f5d5c7e18 RSP=ffff8f0f5d5c7df8
 [...]
@@ -270,7 +271,7 @@ echo 256 | sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
 Be sure to re-check if it worked:
 
 ```bash
-cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+$ cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
 
 256
 ```
@@ -280,7 +281,7 @@ There one of these sizes is the "default huge page size", which will be used in 
 You can check the current default size:
 
 ```bash
-grep Hugepagesize /proc/meminfo
+$ grep Hugepagesize /proc/meminfo
 
 Hugepagesize:       2048 kB
 ```
@@ -301,10 +302,11 @@ One can allocate huge pages at [boot or runtime](https://www.kernel.org/doc/Docu
 
 Huge pages need to be allocated by the kernel as mentioned above, but to be consumable, they also have to be mounted. By default, `systemd` will make `/dev/hugepages` available for the default huge page size.
 
-Feel free to add more mount points if you need different sized ones. An overview can be queried with:
+Feel free to add more mount points if you need different sized ones. An overview can be queried with [hugeadm](https://linux.die.net/man/8/hugeadm):
 
 ```bash
-hugeadm --list-all-mounts
+$ apt install libhugetlbfs-bin
+$ hugeadm --list-all-mounts
 
 Mount Point          Options
 /dev/hugepages       rw,relatime,pagesize=2M

--- a/how-to/virtualisation/libvirt.md
+++ b/how-to/virtualisation/libvirt.md
@@ -239,7 +239,7 @@ Libvirt covers most use cases needed, but if you ever want/need to work around l
 virsh qemu-monitor-command --hmp focal-test-log 'drive_add 0 if=none,file=/var/lib/libvirt/images/test.img,format=raw,id=disk1'
 ```
 
-But since the monitor is so powerful, you can do a lot -- especially for debugging purposes, like showing the guest registers:
+The monitor is a power tool, especially for debugging purposes. For example, one can use the monitor to show the guest registers:
 
 ```bash
 $ virsh qemu-monitor-command --hmp y-ipns 'info registers'

--- a/how-to/virtualisation/multipass.md
+++ b/how-to/virtualisation/multipass.md
@@ -158,7 +158,7 @@ If you already have a hypervisor interacting with {ref}`libvirt`, such as {term}
 be managing virtual machines through tools like [virt-manager](https://virt-manager.org/) or the older {ref}`uvtool <cloud-image-vms-with-uvtool>`.
 
 In that case, integrating Multipass with your existing setup would allow VMs to share the same network bridge for communication
-and be managed using virsh.
+and be managed using virsh. However, Multipass runs as a headless system, so you don't have direct GUI access through virt-viewer. Follow this [guide](https://canonical.com/multipass/docs/set-up-a-graphical-interface) to set up a GUI. 
 
 To begin, integrate Multipass into your existing setup by selecting libvirt as your local driver:
 

--- a/how-to/virtualisation/multipass.md
+++ b/how-to/virtualisation/multipass.md
@@ -1,7 +1,6 @@
 (create-vms-with-multipass)=
 # How to create a VM with Multipass
 
-
 [Multipass](https://multipass.run) is the recommended method for creating Ubuntu VMs on Ubuntu. It's designed for developers who want a fresh Ubuntu environment with a single command, and it works on Linux, Windows and macOS.
 
 On Linux it's available as a snap:
@@ -48,7 +47,7 @@ minikube                                      latest           minikube is local
 
 ## Launch a fresh instance of the Ubuntu Jammy (22.04) LTS
 
-You can launch a fresh instance by specifying either the image name from the list (in this example, 22.04) or using an alias, if the image has one. 
+You can launch a fresh instance by specifying either the image name from the list (in this example, 22.04) or using an alias, if the image has one.
 
 ```bash
 $ multipass launch 22.04
@@ -59,10 +58,10 @@ This command is equivalent to: `multipass launch jammy` or `multipass launch lts
 
 ## Check out the running instances
 
-You can check out the currently running instance(s) by using the "multipass list` command:
+You can check out the currently running instance(s) by using the `multipass list` command:
 
 ```bash
-$ multipass list                                                  
+$ multipass list
 Name                    State             IPv4             Image
 cleansing-guanaco       Running           10.140.26.17     Ubuntu 22.04 LTS
 ```
@@ -72,7 +71,7 @@ cleansing-guanaco       Running           10.140.26.17     Ubuntu 22.04 LTS
 You can use the `multipass info` command to find out more details about the VM instance parameters:
 
 ```bash
-$ multipass info cleansing-guanaco 
+$ multipass info cleansing-guanaco
 Name:           cleansing-guanaco
 State:          Running
 IPv4:           10.140.26.17
@@ -89,10 +88,10 @@ Mounts:         --
 To enter the VM you created, use the `shell` command:
 
 ```bash
-$ multipass shell cleansing-guanaco 
+$ multipass shell cleansing-guanaco
 Welcome to Ubuntu 22.04.1 LTS (GNU/Linux 5.15.0-53-generic x86_64)
 (...)
-ubuntu@cleansing-guanaco:~$ 
+ubuntu@cleansing-guanaco:~$
 ```
 
 ### Disconnect from the instance
@@ -153,23 +152,29 @@ $ multipass list
 No instances found.
 ```
 
-## Integrate with the rest of your virtualization
+## Integrate with the rest of your virtualisation
 
-You might have other virtualization already based on libvirt, either through using the similar older {ref}`uvtool <cloud-image-vms-with-uvtool>` or through the more common [virt-manager](https://virt-manager.org/).
+If you already have a hypervisor interacting with {ref}`libvirt`, such as {term}`QEMU`, {term}`KVM`, or {term}`ESXi`, you might
+be managing virtual machines through tools like [virt-manager](https://virt-manager.org/) or the older {ref}`uvtool <cloud-image-vms-with-uvtool>`.
 
-You might, for example, want those guests to be on the same bridge to communicate with each other, or if you need access to the graphical output for some reason.
+In that case, integrating Multipass with your existing setup would allow VMs to share the same network bridge for communication
+and be managed using virsh.
 
-Fortunately it is possible to integrate this by using the {ref}`libvirt <libvirt>` backend of Multipass:
+To begin, integrate Multipass into your existing setup by selecting libvirt as your local driver:
 
 ```bash
 $ sudo multipass set local.driver=libvirt
 ```
 
-Now when you start a guest you can also access it via tools like [virt-manager](https://virt-manager.org/) or `virsh`:
+```{note}
+If you are having issues interacting with Multipass after switching to the libvirt driver, check if there is a restriction by {term}`AppArmor`, for example. AppArmor may have a default policy which restricts the multipass service from interacting with the [libvert service](https://libvirt.org/daemons.html). So you need to add an explicit permission that allows it.
+```
+
+Start a guest, and access it via tools like [virt-manager](https://virt-manager.org/) or `virsh`:
 
 ```bash
 $ multipass launch lts
-Launched: engaged-amberjack 
+Launched: engaged-amberjack
 
 $ virsh list
  Id    Name                           State

--- a/how-to/virtualisation/ubuntu-on-hyper-v.md
+++ b/how-to/virtualisation/ubuntu-on-hyper-v.md
@@ -20,7 +20,7 @@ The following are typical [system requirements for Hyper-V](https://learn.micros
 
 ## Install Hyper-V
 
-Our first step in enabling Ubuntu is to install Hyper-V, which can be used on the Windows 11 Pro, Enterprise, Education and Server operating systems.
+Our first step in enabling Ubuntu is to install Hyper-V, which can be used on the Windows 11 Pro, Enterprise, Education, and Server operating systems.
 
 Hyper-V is not included in Windows 11 Home, which [would need to be upgraded](https://support.microsoft.com/en-us/windows/upgrade-windows-home-to-windows-pro-ef34d520-e73f-3198-c525-d1a218cc2818) to Windows 11 Pro.
 

--- a/how-to/virtualisation/virtual-machine-manager.md
+++ b/how-to/virtualisation/virtual-machine-manager.md
@@ -23,18 +23,19 @@ You can connect to the libvirt service running on another host by entering the f
 virt-manager -c qemu+ssh://virtnode1.mydomain.com/system
 ```
 
-> **Note**:
-> The above example assumes that SSH connectivity between the management system and the target system has already been configured, and uses **SSH keys** for authentication. SSH keys are needed because libvirt sends the password prompt to another process. See our guide on OpenSSH for details on {ref}`how to set up SSH keys <smart-card-authentication-with-ssh>`.
+```{note}
+The above example assumes that SSH connectivity between the management system and the target system has already been configured, and uses **SSH keys** for authentication. SSH keys are needed because libvirt sends the password prompt to another process. See our guide on OpenSSH for details on {ref}`how to set up SSH keys <smart-card-authentication-with-ssh>`.
+```
 
 ## Use virt-manager to manage guests
 
 ### Guest lifecycle 
 
-When using `virt-manager` it is always important to know the context you're looking at. The main window initially lists only the currently-defined guests. You'll see their **name**, **state** (e.g., 'Shutoff' or 'Running') and a small chart showing the **CPU usage**.
+When using `virt-manager`, it is always important to know the context you're looking at. The main window initially lists only the currently-defined guests. You'll see their **name**, **state** (e.g., 'Shutoff' or 'Running') and a small chart showing the **CPU usage**.
 
 ![virt-manager-gui-start|499x597](https://assets.ubuntu.com/v1/07edc140-virt-manager-gui-start.png) 
 
-In this context, there isn't much to do except start/stop a guest. However, by double-clicking on a guest or by clicking the **Open** button at the top of the window, you can see the guest itself. For a running guest that includes the guest's main-console/virtual-screen output.
+In this context, there isn't much to do except start/stop a guest. However, by double-clicking on a guest or by clicking the **Open** button at the top of the window, you can see the guest itself. For a running guest, that includes the guest's main-console/virtual-screen output.
 
 ![virt-manager-gui-showoutput|690x386](https://assets.ubuntu.com/v1/dda60637-virt-manager-gui-show-output.png) 
 
@@ -84,7 +85,7 @@ virt-viewer -c qemu+ssh://virtnode1.mydomain.com/system <guestname>
 
 Be sure to replace `web_devel` with the appropriate virtual machine name.
 
-If configured to use a **bridged** network interface you can also set up SSH access to the virtual machine.
+If configured to use a **bridged** network interface, you can also set up SSH access to the virtual machine.
 
 ## virt-install
 
@@ -102,34 +103,37 @@ There are several options available when using `virt-install`. For example:
 
 ```bash
 virt-install \
- --name web_devel \
- --ram 8192 \
- --disk path=/home/doug/vm/web_devel.img,bus=virtio,size=50 \
- --cdrom focal-desktop-amd64.iso \
- --network network=default,model=virtio \
- --graphics vnc,listen=0.0.0.0 --noautoconsole --hvm --vcpus=4
+   --name web_devel \
+   --ram 8192 \
+   --disk path=/home/doug/vm/web_devel.img,bus=virtio,size=50 \
+   --cdrom focal-desktop-amd64.iso \
+   --network network=default,model=virtio \
+   --graphics vnc,listen=0.0.0.0 \
+   --noautoconsole \
+   --hvm \
+   --vcpus=4
 ```
 
-There are many more arguments that can be found in the [`virt-install` manpage](https://manpages.ubuntu.com/manpages/jammy/man1/virt-install.1.html). However, explaining those of the example above one by one:
+There are many more arguments that can be found in the [`virt-install` manpage](https://manpages.ubuntu.com/manpages/jammy/man1/virt-install.1.html). However, here is an explanation of arguments used in the example above, one by one:
 
-* `--name web_devel`
+* `--name web_devel`:
    The name of the new virtual machine will be `web_devel`.
-* `--ram 8192`
+* `--ram 8192`:
    Specifies the amount of memory the virtual machine will use (in megabytes).
-* `--disk path=/home/doug/vm/web_devel.img,bus=virtio,size=50`
+* `--disk path=/home/doug/vm/web_devel.img,bus=virtio,size=50`:
    Indicates the path to the virtual disk which can be a file, partition, or logical volume. In this example a file named `web_devel.img` in the current user's directory, with a size of 50 gigabytes, and using `virtio` for the disk bus. Depending on the disk path, `virt-install` may need to run with elevated privileges. 
-* `--cdrom focal-desktop-amd64.iso`
+* `--cdrom focal-desktop-amd64.iso`:
    File to be used as a virtual CD-ROM. The file can be either an ISO file or the path to the host's CD-ROM device.
-* `--network`
+* `--network`:
    Provides details related to the VM's network interface. Here the default network is used, and the interface model is configured for `virtio`.
-* `--graphics vnc,listen=0.0.0.0`
+* `--graphics vnc,listen=0.0.0.0`:
    Exports the guest's virtual console using VNC and on all host interfaces. Typically servers have no GUI, so another GUI-based computer on the Local Area Network (LAN) can connect via VNC to complete the installation.
 * `--noautoconsole`
    Will not automatically connect to the virtual machine's console.
-* `--hvm` : creates a fully virtualised guest.
-* `--vcpus=4` : allocate 4 virtual CPUs.
+* `--hvm`: creates a fully virtualised guest.
+* `--vcpus=4`: allocate 4 virtual CPUs.
 
-After launching `virt-install` you can connect to the virtual machine's console either locally using a GUI (if your server has a GUI), or via a remote VNC client from a GUI-based computer.
+After launching `virt-install`, you can connect to the virtual machine's console either locally using a GUI (if your server has a GUI), or via a remote VNC client from a GUI-based computer.
 
 ## `virt-clone`
 
@@ -140,22 +144,23 @@ virt-clone --auto-clone --original focal
 ```
 
 Options used:
-* `--auto-clone`
+* `--auto-clone`:
    To have `virt-clone` create guest names and disk paths on its own.
-* `--original`
+* `--original`:
    Name of the virtual machine to copy.
 
 You can also use the `-d` or `--debug` option to help troubleshoot problems with `virt-clone`.
 
 Replace *`focal`* with the appropriate virtual machine names for your case.
 
-> **Warning**: 
-> Please be aware that this is a full clone, therefore any sorts of secrets, keys and for example `/etc/machine-id` will be shared. This will cause issues with security and anything that needs to identify the machine like {term}`DHCP`. You most likely want to edit those afterwards and de-duplicate them as needed.
+```{caution}
+Please be aware that this is a full clone, therefore any secrets, keys, and for example, `/etc/machine-id`, will be shared. This will cause issues with security and anything that needs to identify the machine like {term}`DHCP`. You most likely want to edit those afterward and de-duplicate them as needed.
+```
 
 ## Resources
 
-  - See the [KVM](http://www.linux-kvm.org/) home page for more details.
+- See the [KVM](http://www.linux-kvm.org/) home page for more details.
 
-  - For more information on libvirt see the [libvirt home page](http://libvirt.org/)
+- For more information on libvirt see the [libvirt home page](http://libvirt.org/)
 
-  - The [Virtual Machine Manager](http://virt-manager.org/) site has more information on `virt-manager` development.
+- The [Virtual Machine Manager](http://virt-manager.org/) site has more information on `virt-manager` development.

--- a/reference/backups/archive-rotation-shell-script.md
+++ b/reference/backups/archive-rotation-shell-script.md
@@ -2,7 +2,7 @@
 
 # Archive rotation shell script
 
-The {ref}`simple backup shell script <basic-backup-shell-script>` only allows for seven different archives. For a server whose data doesn't change often, this may be enough. If the server has a large amount of data, a more complex rotation scheme should be used.
+The {ref}`simple backup shell script <back-up-using-shell-scripts>` only allows for seven different archives. For a server whose data doesn't change often, this may be enough. If the server has a large amount of data, a more complex rotation scheme should be used.
 
 ## Rotating NFS archives
 


### PR DESCRIPTION
### Description

This PR contains fixes across different files. The changes across them comprise the following:

- Fixing grammar by adding commas in some sentences. This made the sentence easier to read, longer sentences without pauses can be difficult to comprehend because the content is technical. Adding pauses gives the reader time to reflect, it also adheres to grammatical standards.
- The [style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/#notes) represents notes as a code block, not a quote. I updated all references about this.
- A few sentences were difficult to comprehend. For example, in the sentence, *"Once the host is ready to use nested virtualisation it is time to check if the guest instance where the other instance(s) are going to run is able to host these nested VMs."*, The phrase **"where the other instance(s) are going to run is able to host these nested VMs."** is confusing because it keeps repeating the word instance, since the aim was to talk about **nested virtualisation**, I decided to focus on that alone. I updated the phrase to *"can run additional nested VMs inside it."*
- `reference/backups/archive-rotation-shell-script.md`, this file isn't related to this PR. I noticed the issue while building the docs, so I decided to fix it.
- The documentation has consistently added a shell symbol "$" when differentiating an input command and its output. I added them here.
- I included an installation command for using the `hugeadm` tool.

---

### Related Issue

Relevant to canonical/open-documentation-academy#185

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
