### PR TITLE
howto: PXE Netboot corrections

### DIFF
--- a/how-to/installation/how-to-netboot-the-server-installer-on-amd64.md
+++ b/how-to/installation/how-to-netboot-the-server-installer-on-amd64.md
@@ -169,7 +169,7 @@ ln -s /usr/share/cd-boot-images-amd64 /srv/tftp/boot-amd64
    ```
 
 ```{note}
-Setting `cloud-config-url=/dev/null` on the kernel command line prevents cloud-init from downloading the iso twice.
+Setting `cloud-config-url=/dev/null` on the kernel command line prevents cloud-init from downloading the ISO twice.
 ```
 
 As you can see, this downloads the ISO from Ubuntu's servers. You may want to host it somewhere on your infrastructure and change the URL to match.

--- a/how-to/installation/how-to-netboot-the-server-installer-on-amd64.md
+++ b/how-to/installation/how-to-netboot-the-server-installer-on-amd64.md
@@ -27,7 +27,7 @@ There are several implementations of the DHCP/BOOTP and TFTP protocols available
    sudo apt install dnsmasq
    ```
 
-2. Put something like this in `/etc/dnsmasq.conf.d/pxe.conf`:
+2. Put something like this in `/etc/dnsmasq.d/pxe.conf`:
 
    ```
    interface=<your interface>,lo

--- a/how-to/installation/how-to-netboot-the-server-installer-on-amd64.md
+++ b/how-to/installation/how-to-netboot-the-server-installer-on-amd64.md
@@ -137,7 +137,7 @@ ln -s /usr/share/cd-boot-images-amd64 /srv/tftp/boot-amd64
         
     menuentry 'Ubuntu 24.04' {
             gfxmode $linux_gfx_mode
-            linux /vmlinux $vt_handoff quiet splash
+            linux /vmlinuz $vt_handoff quiet splash
             initrd /initrd
     }
    ```

--- a/how-to/installation/how-to-netboot-the-server-installer-on-amd64.md
+++ b/how-to/installation/how-to-netboot-the-server-installer-on-amd64.md
@@ -165,8 +165,13 @@ ln -s /usr/share/cd-boot-images-amd64 /srv/tftp/boot-amd64
     LABEL install
       KERNEL vmlinuz
       INITRD initrd
-      APPEND root=/dev/ram0 ramdisk_size=1500000 ip=dhcp url=http://cdimage.ubuntu.com/ubuntu-server/noble/daily-live/current/noble-live-server-amd64.iso
+      APPEND root=/dev/ram0 ramdisk_size=1500000 cloud-config-url=/dev/null ip=dhcp url=http://cdimage.ubuntu.com/ubuntu-server/noble/daily-live/current/noble-live-server-amd64.iso
    ```
+
+```{note}
+Setting `cloud-config-url=/dev/null` on the kernel command line prevents cloud-init from downloading the iso twice.
+```
+
 As you can see, this downloads the ISO from Ubuntu's servers. You may want to host it somewhere on your infrastructure and change the URL to match.
 
 This configuration is very simple. PXELINUX has many, many options, and you can [consult its documentation](https://wiki.syslinux.org/wiki/index.php?title=PXELINUX) for more.


### PR DESCRIPTION
### Description

Three little fixes for the PXE/TFTP guide:
- `dnsmasq` in Ubuntu [uses `/etc/dnsmasq.d`](https://git.launchpad.net/ubuntu/+source/dnsmasq/tree/debian/dnsmasq.install#n7) as its configuration direction.
- Because of cloud-init's (deprecated) behavior ([docs](https://cloudinit.readthedocs.io/en/latest/explanation/kernel-command-line.html#kernel-cloud-config-url-configuration), [source](https://github.com/canonical/cloud-init/blob/de415c61c011dca8b83c3c174213246ac50154fe/cloudinit/cmd/main.py#L194)), cloud-init may attempt to download the ISO (again) as cloud-config. We can add a parameter to the CLI to prevent that from occurring, saving time and RAM during boot.
- Consistent kernel executable name

---

### Commit Message for Squash Merge

We typically squash commits when merging. You can specify the commit message that should be used in this case if you wish.
Provide the desired commit message below:

```
howto: PXE Netboot corrections
```

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [ ] ~~My pull request is linked to an existing issue (if applicable).~~
- [x] I have tested my changes, and they work as expected.