### PR TITLE
Add a link to authd documentation

### DIFF
--- a/explanation/intro-to/samba.md
+++ b/explanation/intro-to/samba.md
@@ -13,34 +13,34 @@ There are several services common to Windows environments that your Ubuntu syste
 
 These services use the Server Message Block (SMB) protocol to facilitate the sharing of files, folders, volumes, and the sharing of printers throughout the network. 
 
-- **File server**
-Samba can be {ref}`configured as a file server <samba-file-server>` to share files with Windows clients - our guide will walk you through that process.
+File server
+: Samba can be {ref}`configured as a file server <samba-file-server>` to share files with Windows clients - our guide will walk you through that process.
 
-- **Print server**
-Samba can also be {ref}`configured as a print server <samba-print-server>` to share printer access with Windows clients, as detailed in this guide. 
+Print server
+: Samba can also be {ref}`configured as a print server <samba-print-server>` to share printer access with Windows clients, as detailed in this guide. 
 
 ### Directory services
 
 These services share vital information about the computers and users of the network. They use technologies like the Lightweight Directory Access Protocol (LDAP) and Microsoft Active Directory. 
 
-- **Microsoft Active Directory**
-An Active Directory domain is a collection of users, groups, or hardware components within a Microsoft Active Directory network. This guide will show you how to set up your server as a {ref}`member of an Active Directory domain <member-server-in-an-ad-domain>`.
+Microsoft Active Directory
+: An Active Directory domain is a collection of users, groups, or hardware components within a Microsoft Active Directory network. This guide will show you how to set up your server as a {ref}`member of an Active Directory domain <member-server-in-an-ad-domain>`.
 
-- NT4 Domain Controller *(deprecated)*
-This guide will show you how to configure your Samba server to appear {ref}`as a Windows NT4-style domain controller <nt4-domain-controller-legacy>`.
+NT4 Domain Controller *(deprecated)*
+: This guide will show you how to configure your Samba server to appear {ref}`as a Windows NT4-style domain controller <nt4-domain-controller-legacy>`.
 
-- OpenLDAP backend *(deprecated)*
-This guide will show you how to integrate Samba with {ref}`LDAP in Windows NT4 mode <openldap-backend-legacy>`. 
+OpenLDAP backend *(deprecated)*
+: This guide will show you how to integrate Samba with {ref}`LDAP in Windows NT4 mode <openldap-backend-legacy>`. 
 
 ### Authentication and access
 
 These services establish the identity of a computer or network user, and determine the level of access that should be granted to the computer or user. The services use such principles and technologies as file permissions, group policies, and the Kerberos authentication service.
 
-- **Share access controls**
-This article provides more details on {ref}`controlling access to shared directories <share-access-controls>`.
+Share access controls
+: This article provides more details on {ref}`controlling access to shared directories <share-access-controls>`.
 
-- **AppArmor profile for Samba**
-This guide will briefly cover how to {ref}`set up a profile for Samba <samba-apparmor-profile>` using the Ubuntu security module, AppArmor.
+AppArmor profile for Samba
+: This guide will briefly cover how to {ref}`set up a profile for Samba <samba-apparmor-profile>` using the Ubuntu security module, AppArmor.
 
-- **Mounting CIFS shares permanently**
-  This guide will show you {ref}`how to set up Common Internet File System (CIFS) shares <mount-cifs-shares-permanently>` to automatically provide access to network files and resources.
+Mounting CIFS shares permanently
+: This guide will show you {ref}`how to set up Common Internet File System (CIFS) shares <mount-cifs-shares-permanently>` to automatically provide access to network files and resources.

--- a/how-to/networking/install-nfs.md
+++ b/how-to/networking/install-nfs.md
@@ -11,6 +11,10 @@ Some of the most notable benefits that NFS can provide are:
 
   - Storage devices such as floppy disks, CDROM drives, and USB Thumb drives can be used by other machines on the network. This may reduce the number of removable media drives throughout the network.
 
+```{warning}
+If you use **NFS and authd** at the same time, you must add a Kerberos configuration on the client and the server. Otherwise, you'd encounter permission issues due to mismatched user and group identifiers. For details, see [Using authd with NFS](https://documentation.ubuntu.com/authd/en/stable/howto/use-with-nfs/).
+```
+
 ## Installation
 
 At a terminal prompt enter the following command to install the NFS Server:

--- a/how-to/samba/file-server.md
+++ b/how-to/samba/file-server.md
@@ -5,6 +5,12 @@ One of the most common ways to network Ubuntu and Windows computers is to config
 
 The server will be configured to share files with any client on the network without prompting for a password. If your environment requires stricter Access Controls see [Share Access Control](share-access-controls.md).
 
+```{warning}
+If you use **Samba and authd** at the same time, you must specify user and group mapping. Otherwise, you'd encounter permission issues due to mismatched user and group identifiers.
+
+Instead of this guide, follow [Steps for the server](https://documentation.ubuntu.com/authd/en/latest/howto/use-with-samba/#steps-for-the-server) in the *Using authd with Samba* guide.
+```
+
 ## Install Samba
 
 From a terminal prompt, enter:
@@ -57,23 +63,28 @@ The main Samba configuration file is located in `/etc/samba/smb.conf`. The defau
     : Allows clients to connect to the share without supplying a password.
 
     `read only`
-    : determines if the share is read only or if write privileges are granted. Write privileges are allowed only when the value is *no*, as is seen in this example. If the value is *yes*, then access to the share is read only.
+    : Determines if the share is read only or if write privileges are granted. Write privileges are allowed only when the value is *no*, as is seen in this example. If the value is *yes*, then access to the share is read only.
 
     `create mask`
     : Determines the permissions that new files will have when created.
 
 ### Create the directory
 
-Now that Samba is configured, the directory needs to be created and the permissions changed.
+From a terminal, run the following commands.
 
-From a terminal, run the following commands:
+1. Create the directory:
 
-```bash
-sudo mkdir -p /srv/samba/share
-sudo chown nobody:nogroup /srv/samba/share/
-```
+    ```bash
+    sudo mkdir -p /srv/samba/share
+    ```
 
-The `-p` switch tells `mkdir` to create the entire directory tree if it doesn't already exist.
+    The `-p` switch tells `mkdir` to create the entire directory tree if it doesn't already exist.
+
+2. Change the permissions:
+
+    ```bash
+    sudo chown nobody:nogroup /srv/samba/share/
+    ```
 
 ### Enable the new configuration
 

--- a/how-to/samba/file-server.md
+++ b/how-to/samba/file-server.md
@@ -7,62 +7,66 @@ The server will be configured to share files with any client on the network with
 
 ## Install Samba
 
-The first step is to install the `samba` package. From a terminal prompt enter:
+From a terminal prompt, enter:
 
 ```bash
 sudo apt install samba
 ```
 
-That's all there is to it; you are now ready to configure Samba to share files.
+You are now ready to configure Samba to share files.
 
 ## Configure Samba as a file server
 
 The main Samba configuration file is located in `/etc/samba/smb.conf`. The default configuration file contains a significant number of comments, which document various configuration directives.
 
-> **Note**:
-> Not all available options are included in the default configuration file. See the [`smb.conf` man page](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html) or the [Samba HOWTO Collection](https://www.samba.org/samba/docs/old/Samba3-HOWTO/) for more details.
+1. Edit the `workgroup` parameter in the `[global]` section of `/etc/samba/smb.conf`. Change it to better match your environment:
 
-First, edit the `workgroup` parameter in the *\[global\]* section of `/etc/samba/smb.conf` and change it to better match your environment:
+    ```ini
+    workgroup = EXAMPLE
+    ```
 
-```text
-workgroup = EXAMPLE
-```
+2. Create a new section at the bottom of the file, or uncomment one of the examples, for the directory you want to share:
 
-Create a new section at the bottom of the file, or uncomment one of the examples, for the directory you want to share:
+    ```ini
+    [share]
+        comment = Ubuntu File Server Share
+        path = /srv/samba/share
+        browsable = yes
+        guest ok = yes
+        read only = no
+        create mask = 0755
+    ```
 
-```text
-[share]
-    comment = Ubuntu File Server Share
-    path = /srv/samba/share
-    browsable = yes
-    guest ok = yes
-    read only = no
-    create mask = 0755
-```
+    `[share]`
+    : A name for the file share configuration. It is a good idea to name a share after a directory on the file system. Another example would be a share name of `[qa]` with a path of `/srv/samba/qa`.
 
-- **`comment`**
-A short description of the share. Adjust to fit your needs.
+    `comment`
+    : A short description of the share. Adjust to fit your needs.
 
-- **`path`**
-The path to the directory you want to share.
-    
-  > **Note**:
-  > This example uses `/srv/samba/sharename` because, according to the {term}`Filesystem Hierarchy Standard (FHS) <FHS>`, [`/srv`](http://www.pathname.com/fhs/pub/fhs-2.3.html#SRVDATAFORSERVICESPROVIDEDBYSYSTEM) is where site-specific data should be served. Technically, Samba shares can be placed anywhere on the {term}`filesystem` as long as the permissions are correct, but adhering to standards is recommended.
+    `path`
+    : The path to the directory you want to share.
 
-- **`browsable`**
-Enables Windows clients to browse the shared directory using Windows Explorer.
+        ```{note}
+        This example uses `/srv/samba/share` because, according to the {term}`Filesystem Hierarchy Standard (FHS) <FHS>`, [`/srv`](http://www.pathname.com/fhs/pub/fhs-2.3.html#SRVDATAFORSERVICESPROVIDEDBYSYSTEM) is where site-specific data should be served. Technically, Samba shares can be placed anywhere on the {term}`filesystem` as long as the permissions are correct, but adhering to standards is recommended.
+        ```
 
-- **`guest ok`**
-Allows clients to connect to the share without supplying a password.
+    `browsable`
+    : Enables Windows clients to browse the shared directory using Windows Explorer.
 
-- **`read only`** determines if the share is read only or if write privileges are granted. Write privileges are allowed only when the value is *no*, as is seen in this example. If the value is *yes*, then access to the share is read only.
+    `guest ok`
+    : Allows clients to connect to the share without supplying a password.
 
-- **`create mask`**
-Determines the permissions that new files will have when created.
+    `read only`
+    : determines if the share is read only or if write privileges are granted. Write privileges are allowed only when the value is *no*, as is seen in this example. If the value is *yes*, then access to the share is read only.
+
+    `create mask`
+    : Determines the permissions that new files will have when created.
 
 ### Create the directory
 
-Now that Samba is configured, the directory needs to be created and the permissions changed. From a terminal, run the following commands:
+Now that Samba is configured, the directory needs to be created and the permissions changed.
+
+From a terminal, run the following commands:
 
 ```bash
 sudo mkdir -p /srv/samba/share
@@ -73,27 +77,28 @@ The `-p` switch tells `mkdir` to create the entire directory tree if it doesn't 
 
 ### Enable the new configuration
 
-Finally, restart the Samba services to enable the new configuration by running the following command:
+1. Restart the Samba services to enable the new configuration by running the following command:
 
-```bash
-sudo systemctl restart smbd.service nmbd.service
-```
+    ```bash
+    sudo systemctl restart smbd.service nmbd.service
+    ```
 
-> **Warning**:
-> Once again, the above configuration gives full access to any client on the local network. For a more secure configuration see [Share Access Control](share-access-controls.md).
+    ```{warning}
+    Once again, the above configuration gives full access to any client on the local network. For a more secure configuration see [Share Access Control](share-access-controls.md).
+    ```
 
-From a Windows client you should now be able to browse to the Ubuntu file server and see the shared directory. If your client doesn't show your share automatically, try to access your server by its IP address, e.g. `\\192.168.1.1`, in a Windows Explorer window. To check that everything is working try creating a directory from Windows.
+2. From a Windows client you should now be able to browse to the Ubuntu file server and see the shared directory.
 
-To create additional shares simply create new `[sharename]` sections in `/etc/samba/smb.conf`, and restart Samba. Just make sure that the directory you want to share actually exists and the permissions are correct.
+    If your client doesn't show your share automatically, try to access your server by its IP address, e.g. `\\192.168.1.1`, in a Windows Explorer window. To check that everything is working try creating a directory from Windows.
 
-The file share named `[share]` and the path `/srv/samba/share` used in this example can be adjusted to fit your environment. It is a good idea to name a share after a directory on the file system. Another example would be a share name of `[qa]` with a path of `/srv/samba/qa`.
+3. To create additional shares, create new `[sharename]` sections in `/etc/samba/smb.conf`, and restart Samba. Just make sure that the directory that you want to share actually exists and the permissions are correct.
 
 ## Further reading
 
-  - For in-depth Samba configurations see the [Samba how-to collection](https://www.samba.org/samba/docs/old/Samba3-HOWTO/)
+  - For in-depth Samba configurations, see the [Samba how-to collection](https://www.samba.org/samba/docs/old/Samba3-HOWTO/) or the [`smb.conf` man page](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html).
 
   - The guide is also available [in printed format](http://www.amazon.com/exec/obidos/tg/detail/-/0131882228).
 
-  - O'Reilly's [Using Samba](http://www.oreilly.com/catalog/9780596007690/) is another good reference.
+  - O'Reilly's [Using Samba](http://www.oreilly.com/catalog/9780596007690/).
 
   - The [Ubuntu Wiki Samba](https://help.ubuntu.com/community/Samba) page.

--- a/how-to/samba/mount-cifs-shares-permanently.md
+++ b/how-to/samba/mount-cifs-shares-permanently.md
@@ -1,11 +1,11 @@
 (mount-cifs-shares-permanently)=
-# How to mount CIFS shares permanently
+# Mount CIFS shares permanently
 
-Common Internet File System (CIFS) shares are a file-sharing protocol used (mainly) in Windows for accessing files and resources (such as printers) over a network.
+Common Internet File System (CIFS) shares are a file-sharing protocol used mainly in Windows for accessing files and resources, such as printers, over a network.
 
 Permanently mounting CIFS shares involves configuring your system to automatically connect to these shared resources when the system boots, which is useful when network users need consistent and regular access to them.
 
-In this guide, we will show you how to permanently mount and access CIFS shares. The shares can be hosted on a Windows computer/server, or on a Linux/UNIX server running [Samba](https://discourse.ubuntu.com/t/samba-introduction/11888). If you want to know how to host shares, you will need to use [Samba](https://discourse.ubuntu.com/t/samba-introduction/11888).
+In this guide, we will show you how to permanently mount and access CIFS shares. The shares can be hosted on a Windows computer/server, or on a Linux/UNIX server running Samba. If you want to know how to host shares, see {ref}`introduction-to-samba`.
 
 ## Prerequisites
 
@@ -20,93 +20,88 @@ In order to use this guide, you will need to ensure that your network connection
 
 ## Install CIFS
 
-To install CIFS, run the following command:
+Run the following command:
 
 ```bash
-sudo apt-get install cifs-utils
+sudo apt install cifs-utils
 ```
 
 ## Mount unprotected (guest) network folders
 
-First, let's create the mount directory. You will need a separate directory for each mount:
+1. Let's create the mount directory. You will need a separate directory for each mount:
 
-```bash
-sudo mkdir /media/windowsshare
-```
+    ```bash
+    sudo mkdir /media/windowsshare
+    ```
 
-Then edit your `/etc/fstab` file (with root privileges) to add this line:
+2. Edit your `/etc/fstab` file (with root privileges) to add this line:
 
-```text
-//servername/sharename /media/windowsshare cifs guest,uid=1000 0 0
-```
+    ```text
+    //servername/sharename /media/windowsshare cifs guest,uid=1000 0 0
+    ```
 
-Where:
+    Where:
 
-* `servername` is the server hostname or IP address,
-* `guest` indicates you don't need a password to access the share,
-* `uid=1000` makes the Linux user (specified by the ID) the owner of the mounted share, allowing them to rename files, and
-* If there is any space in the server path, you need to replace it by `\040`, for example:
-   `//servername/My\040Documents`
+      * `servername` is the server hostname or IP address,
+      * `guest` indicates you don't need a password to access the share,
+      * `uid=1000` makes the Linux user (specified by the ID) the owner of the mounted share, allowing them to rename files, and
+      * If there is any space in the server path, you need to replace it by `\040`, for example:
 
-After you add the entry to `/etc/fstab`, type:
+         ```
+         //servername/My\040Documents
+         ```
 
-```bash
-sudo mount /media/windowsshare
-```
+3. Mount the network folder:
+
+    ```bash
+    sudo mount /media/windowsshare
+    ```
 
 ## Mount password-protected network folders
 
-To auto-mount a password-protected share, you can edit `/etc/fstab` (with root privileges), and add this line:
+To auto-mount a password-protected share:
 
-```text
-//servername/sharename /media/windowsshare cifs username=msusername,password=mspassword 0 0
-```
+1. Using a text editor, create a file for your remote server’s login credential:
 
-This is not a good idea however: `/etc/fstab` is readable by everyone -- and so is your Windows password within it. The way around this is to use a credentials file. This is a file that contains just the username and password.
+    ```bash
+    gedit ~/.smbcredentials
+    ```
 
-### Create a credentials file
+2. Enter your Windows username and password in the file:
 
-Using a text editor, create a file for your remote server’s logon credential:
+    ```ini
+    username=msusername
 
-```bash
-gedit ~/.smbcredentials
-```
+    password=mspassword
+    ```
 
-Enter your Windows username and password in the file:
+3. Save the file and exit the editor.
 
-```text
-username=msusername
+4. Change the permissions of the file to prevent unwanted access to your credentials:
 
-password=mspassword
-```
+    ```bash
+    chmod 600 ~/.smbcredentials
+    ```
 
-Save the file and exit the editor.
+5. Edit your `/etc/fstab` file (with root privileges) to add this line:
 
-Change the permissions of the file to prevent unwanted access to your credentials:
+    ```text
+    //servername/sharename /media/windowsshare cifs credentials=/home/ubuntuusername/.smbcredentials 0 0
+    ```
 
-```bash
-chmod 600 ~/.smbcredentials
-```
+6. Save the file and exit the editor.
 
-Then edit your `/etc/fstab` file (with root privileges) to add this line (replacing the insecure line in the example above, if you added it):
+7. Test mounting the share:
 
-```text
-//servername/sharename /media/windowsshare cifs credentials=/home/ubuntuusername/.smbcredentials 0 0
-```
+    ```bash
+    sudo mount /media/windowsshare
+    ```
 
-Save the file and exit the editor.
-
-Finally, test mounting the share by running:
-
-```bash
-sudo mount /media/windowsshare
-```
-
-If there are no errors, you should test how it works after a reboot. Your remote share should mount automatically. However, if the remote server goes offline, the boot process could present errors because it won't be possible to mount the share.
+8. If there are no errors, test how it works after a reboot. Your remote share should mount automatically. However, if the remote server goes offline, the boot process could present errors because it won't be possible to mount the share.
 
 ## Changing the share ownership
 
-If you need to change the owner of a share, you'll need to add a **UID** (short for 'User ID') or **{term}`GID`** (short for 'Group ID') parameter to the share's mount options:
+If you need to change the owner of a share, add a **UID** (short for *User ID*) or **{term}`GID`** (short for *Group ID*) parameter to the share's mount options:
 
 ```text
 //servername/sharename /media/windowsshare cifs uid=ubuntuusername,credentials=/home/ubuntuusername/.smbcredentials 0 0
@@ -116,45 +111,55 @@ If you need to change the owner of a share, you'll need to add a **UID** (short 
 
 In addition to the initial assumptions, we're assuming here that your username and password are the same on both the Ubuntu machine and the network drive.
 
-### Install `libpam-mount`
+1. Install `libpam-mount`:
 
-```bash
-sudo apt-get install libpam-mount
-```
+    ```bash
+    sudo apt install libpam-mount
+    ```
 
-Edit `/etc/security/pam_mount.conf.xml` using your preferred text editor.
+2. Edit `/etc/security/pam_mount.conf.xml` using your preferred text editor:
 
-```bash
-sudo gedit /etc/security/pam_mount.conf.xml
-```
+    ```bash
+    sudo gedit /etc/security/pam_mount.conf.xml
+    ```
 
-First, we're moving the user-specific config parts to a file which users can actually edit themselves. 
+3. We're moving the user-specific config parts to a file which users can actually edit themselves. 
 
-Remove the commenting tags `(<!--` and `-->)` surrounding the section called `<luserconf name=".pam_mount.conf.xml" />`. We also need to enable some extra mount options to be used. For that, edit the "`<mntoptions allow=...`" tag and add `uid,gid,dir_mode,credentials` to it.
+    Remove the commenting tags (`<!--` and `-->`) surrounding the section called `<luserconf name=".pam_mount.conf.xml" />`.
 
-Save the file when done. With this in place, users can create their own `~/.pam_mount.conf.xml`.
+    We also need to enable some extra mount options to be used. For that, edit the `<mntoptions allow=...` tag and add `uid,gid,dir_mode,credentials` to it.
 
-```bash
-gedit ~/.pam_mount.conf.xml
-```
+4. Save the file when done.
 
-Add the following:
+5. Users can now create their own `~/.pam_mount.conf.xml`:
 
-```text
-<?xml version="1.0" encoding="utf-8" ?>
+    ```bash
+    gedit ~/.pam_mount.conf.xml
+    ```
 
-<pam_mount>
+6. In `~/.pam_mount.conf.xml`, enter the following:
 
-<volume options="uid=%(USER),gid=100,dir_mode=0700,credentials=/home/ubuntuusername/.smbcredentials,nosuid,nodev" user="*" mountpoint="/media/windowsshare" path="sharename" server="servername" fstype="cifs" />
+    ```xml
+    <?xml version="1.0" encoding="utf-8" ?>
 
-</pam_mount>
-```
+    <pam_mount>
+
+    <volume
+      options="uid=%(USER),gid=100,dir_mode=0700,credentials=/home/ubuntuusername/.smbcredentials,nosuid,nodev"
+      user="*"
+      mountpoint="/media/windowsshare"
+      path="sharename"
+      server="servername"
+      fstype="cifs" />
+
+    </pam_mount>
+    ```
 
 ## Troubleshooting
 
 ### Login errors
 
-If you get the error "mount error(13) permission denied", then the server denied your access. Here are the first things to check:
+If you get the error `mount error(13) permission denied`, then the server denied your access. Here are the first things to check:
 
 * Are you using a valid username and password? Does that account really have access to this folder?
 * Do you have blank space in your credentials file? It should be `password=mspassword`, not `password = mspassword`.

--- a/how-to/samba/mount-cifs-shares-permanently.md
+++ b/how-to/samba/mount-cifs-shares-permanently.md
@@ -99,6 +99,12 @@ To auto-mount a password-protected share:
 
 8. If there are no errors, test how it works after a reboot. Your remote share should mount automatically. However, if the remote server goes offline, the boot process could present errors because it won't be possible to mount the share.
 
+## Mount network folders with authd
+
+If you use Samba and authd at the same time, you must specify user and group mapping. Otherwise, you'd encounter permission issues due to mismatched user and group identifiers.
+
+Follow [Steps for the client](https://documentation.ubuntu.com/authd/en/latest/howto/use-with-samba/#steps-for-the-client) in the *Using authd with Samba* guide.
+
 ## Changing the share ownership
 
 If you need to change the owner of a share, add a **UID** (short for *User ID*) or **{term}`GID`** (short for *Group ID*) parameter to the share's mount options:


### PR DESCRIPTION
### Description

With NFS client and server, you must [add certain configuration](https://documentation.ubuntu.com/authd/en/stable/howto/use-with-nfs/) if you also use authd, otherwise NFS access breaks. This is documented only in the authd guide but our NFS documentation makes no mention of it.

This PR adds a warning at the top of the NFS guide and points the user to the necessary resources.

Alternatively, this could also be a step in the NFS client and NFS server setup, but that would duplicate the same information several times across one page.

---

### Related Issue

I'm also cross-linking from authd back to NFS: https://github.com/ubuntu/authd/pull/885

---

### Commit Message for Squash Merge

We typically squash commits when merging. You can specify the commit message that should be used in this case if you wish.
Provide the desired commit message below:

Something like "Cross-linking NFS with authd" is fine.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] I have tested my changes, and they work as expected.
