### PR TITLE
Add links to authd from NFS and Samba (limited PR)

### DIFF
--- a/how-to/networking/install-nfs.md
+++ b/how-to/networking/install-nfs.md
@@ -11,6 +11,12 @@ Some of the most notable benefits that NFS can provide are:
 
   - Storage devices such as floppy disks, CDROM drives, and USB Thumb drives can be used by other machines on the network. This may reduce the number of removable media drives throughout the network.
 
+```{warning}
+If you use **NFS and authd** at the same time, you must add a Kerberos configuration on the client and the server. Otherwise, you'd encounter permission issues due to mismatched user and group identifiers.
+
+For details, see [Using authd with NFS](https://documentation.ubuntu.com/authd/en/stable/howto/use-with-nfs/).
+```
+
 ## Installation
 
 At a terminal prompt enter the following command to install the NFS Server:

--- a/how-to/networking/install-nfs.md
+++ b/how-to/networking/install-nfs.md
@@ -12,7 +12,7 @@ Some of the most notable benefits that NFS can provide are:
   - Storage devices such as floppy disks, CDROM drives, and USB Thumb drives can be used by other machines on the network. This may reduce the number of removable media drives throughout the network.
 
 ```{warning}
-If you use **NFS and authd** at the same time, you must add a Kerberos configuration on the client and the server. Otherwise, you'd encounter permission issues due to mismatched user and group identifiers.
+If you use **NFS and authd** at the same time, you must add a Kerberos configuration on both the client and the server. Otherwise, you will encounter permission issues due to mismatched user and group identifiers.
 
 For details, see [Using authd with NFS](https://documentation.ubuntu.com/authd/en/stable/howto/use-with-nfs/).
 ```

--- a/how-to/samba/file-server.md
+++ b/how-to/samba/file-server.md
@@ -6,9 +6,9 @@ One of the most common ways to network Ubuntu and Windows computers is to config
 The server will be configured to share files with any client on the network without prompting for a password. If your environment requires stricter Access Controls see [Share Access Control](share-access-controls.md).
 
 ```{warning}
-If you use **Samba and authd** at the same time, you must specify user and group mapping. Otherwise, you'd encounter permission issues due to mismatched user and group identifiers.
+If you use **Samba and authd** at the same time, you must specify user and group mapping. Otherwise, you will encounter permission issues due to mismatched user and group identifiers.
 
-Instead of this guide, follow [Steps for the server](https://documentation.ubuntu.com/authd/en/latest/howto/use-with-samba/#steps-for-the-server) in the *Using authd with Samba* guide.
+If you *are* using Samba with authd, you should follow the instructions in the [steps for the server](https://documentation.ubuntu.com/authd/en/latest/howto/use-with-samba/#steps-for-the-server) guide in the authd documentation instead.
 ```
 
 ## Install Samba

--- a/how-to/samba/file-server.md
+++ b/how-to/samba/file-server.md
@@ -5,6 +5,12 @@ One of the most common ways to network Ubuntu and Windows computers is to config
 
 The server will be configured to share files with any client on the network without prompting for a password. If your environment requires stricter Access Controls see [Share Access Control](share-access-controls.md).
 
+```{warning}
+If you use **Samba and authd** at the same time, you must specify user and group mapping. Otherwise, you'd encounter permission issues due to mismatched user and group identifiers.
+
+Instead of this guide, follow [Steps for the server](https://documentation.ubuntu.com/authd/en/latest/howto/use-with-samba/#steps-for-the-server) in the *Using authd with Samba* guide.
+```
+
 ## Install Samba
 
 The first step is to install the `samba` package. From a terminal prompt enter:

--- a/how-to/samba/mount-cifs-shares-permanently.md
+++ b/how-to/samba/mount-cifs-shares-permanently.md
@@ -5,7 +5,7 @@ Common Internet File System (CIFS) shares are a file-sharing protocol used (main
 
 Permanently mounting CIFS shares involves configuring your system to automatically connect to these shared resources when the system boots, which is useful when network users need consistent and regular access to them.
 
-In this guide, we will show you how to permanently mount and access CIFS shares. The shares can be hosted on a Windows computer/server, or on a Linux/UNIX server running Samba. If you want to know how to host shares, see see {ref}`introduction-to-samba`.
+In this guide, we will show you how to permanently mount and access CIFS shares. The shares can be hosted on a Windows computer/server, or on a Linux/UNIX server running Samba. If you want to know how to host shares, see {ref}`introduction-to-samba`.
 
 ## Prerequisites
 
@@ -114,9 +114,9 @@ If you need to change the owner of a share, you'll need to add a **UID** (short 
 
 ## Mount network folders with authd
 
-If you use Samba and authd at the same time, you must specify user and group mapping. Otherwise, you'd encounter permission issues due to mismatched user and group identifiers.
+If you use Samba and authd at the same time, you must specify user and group mapping. Otherwise, you will encounter permission issues due to mismatched user and group identifiers.
 
-Follow [Steps for the client](https://documentation.ubuntu.com/authd/en/latest/howto/use-with-samba/#steps-for-the-client) in the *Using authd with Samba* guide.
+If you *are* using Samba with authd, follow the instructions in the [steps for the client](https://documentation.ubuntu.com/authd/en/latest/howto/use-with-samba/#steps-for-the-client) guide in the authd documentation.
 
 ## Mount password-protected shares using `libpam-mount`
 

--- a/how-to/samba/mount-cifs-shares-permanently.md
+++ b/how-to/samba/mount-cifs-shares-permanently.md
@@ -5,7 +5,7 @@ Common Internet File System (CIFS) shares are a file-sharing protocol used (main
 
 Permanently mounting CIFS shares involves configuring your system to automatically connect to these shared resources when the system boots, which is useful when network users need consistent and regular access to them.
 
-In this guide, we will show you how to permanently mount and access CIFS shares. The shares can be hosted on a Windows computer/server, or on a Linux/UNIX server running [Samba](https://discourse.ubuntu.com/t/samba-introduction/11888). If you want to know how to host shares, you will need to use [Samba](https://discourse.ubuntu.com/t/samba-introduction/11888).
+In this guide, we will show you how to permanently mount and access CIFS shares. The shares can be hosted on a Windows computer/server, or on a Linux/UNIX server running Samba. If you want to know how to host shares, see see {ref}`introduction-to-samba`.
 
 ## Prerequisites
 
@@ -111,6 +111,12 @@ If you need to change the owner of a share, you'll need to add a **UID** (short 
 ```text
 //servername/sharename /media/windowsshare cifs uid=ubuntuusername,credentials=/home/ubuntuusername/.smbcredentials 0 0
 ```
+
+## Mount network folders with authd
+
+If you use Samba and authd at the same time, you must specify user and group mapping. Otherwise, you'd encounter permission issues due to mismatched user and group identifiers.
+
+Follow [Steps for the client](https://documentation.ubuntu.com/authd/en/latest/howto/use-with-samba/#steps-for-the-client) in the *Using authd with Samba* guide.
 
 ## Mount password-protected shares using `libpam-mount`
 


### PR DESCRIPTION
### Description

With NFS client and server, you must [add certain configuration](https://documentation.ubuntu.com/authd/en/stable/howto/use-with-nfs/) if you also use authd, otherwise NFS access breaks. This is documented only in the authd guide but our NFS documentation makes no mention of it.

This PR adds a warning at the top of the NFS guide and points the user to the necessary resources.

There's a similar change in Samba guides: a warning at the top of `how-to/samba/file-server.md` and a new section representing an alternative user path in `how-to/samba/mount-cifs-shares-permanently.md`.

---

### Related Issue

I originally made the changes in #224 but the additional style updates risked creating a conflict. This PR contributes just the links and keeps the rest intact.

I'm also cross-linking from authd back to NFS: https://github.com/ubuntu/authd/pull/885

---

### Commit Message for Squash Merge

We typically squash commits when merging. You can specify the commit message that should be used in this case if you wish.
Provide the desired commit message below:

Something like "Cross-linking NFS and Samba with authd" is fine.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] I have tested my changes, and they work as expected.
