### PR TITLE
Make the iSCSI page compliant with the diataxis framework

### DIFF
--- a/explanation/storage.rst
+++ b/explanation/storage.rst
@@ -5,13 +5,11 @@ Storage
 
 * :ref:`About LVM <about-lvm>` provides more detail about Logical Volume
   Management
-* :ref:`iSCSI <iscsi-initiator-or-client>`
 
 .. toctree::
     :hidden:
 
     About LVM <storage/about-lvm>
-    iSCSI <storage/iscsi-initiator-or-client>
 
 See also
 ========

--- a/how-to/storage.rst
+++ b/how-to/storage.rst
@@ -3,13 +3,14 @@
 Storage
 ********
 
-The Ubuntu Server installer can set up and install to Logical Volume Management
-(LVM) partitions.
+* The Ubuntu Server installer can set up and install to :ref:`Logical Volume Management (LVM) <manage-logical-volumes>` partitions.
+* Ubuntu Server can be configured as both an :ref:`iSCSI initiator and an iSCSI target. <iscsi-initiator-or-client>`
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    Manage logical volumes <storage/manage-logical-volumes>
+   iSCSI <storage/iscsi-initiator-or-client>
 
 See also
 ========

--- a/how-to/storage/iscsi-initiator-or-client.md
+++ b/how-to/storage/iscsi-initiator-or-client.md
@@ -15,11 +15,15 @@
 Ubuntu Server can be configured as both: **iSCSI initiator** and **iSCSI target**. This guide provides commands and configuration options to setup an **iSCSI initiator** (or Client).
 
 ```{note}
+<<<<<<< HEAD
 <<<<<<< HEAD:explanation/storage/iscsi-initiator-or-client.md
 It is assumed that **you already have an iSCSI target on your local network** and have the appropriate rights to connect to it. The instructions for setting up a target vary greatly between hardware providers, so consult your vendor documentation to configure your specific iSCSI target.
 =======
 It is assumed that **you already have an iSCSI target on your local network** and have the appropriate rights to connect to it. The instructions for setting up a target vary greatly between hardware providers, so consult your vendor documentation to configure your specific iSCSI target.*
 >>>>>>> 2ee0225 (make the iscsi page compliant with the diataxis framework):how-to/storage/iscsi-initiator-or-client.md
+=======
+It is assumed that **you already have an iSCSI target on your local network** and have the appropriate rights to connect to it. The instructions for setting up a target vary greatly between hardware providers, so consult your vendor documentation to configure your specific iSCSI target.
+>>>>>>> ab5e0bb (fix merge conflict)
 ```
 
 ## Network Interfaces Configuration

--- a/how-to/storage/iscsi-initiator-or-client.md
+++ b/how-to/storage/iscsi-initiator-or-client.md
@@ -15,15 +15,7 @@
 Ubuntu Server can be configured as both: **iSCSI initiator** and **iSCSI target**. This guide provides commands and configuration options to setup an **iSCSI initiator** (or Client).
 
 ```{note}
-<<<<<<< HEAD
-<<<<<<< HEAD:explanation/storage/iscsi-initiator-or-client.md
 It is assumed that **you already have an iSCSI target on your local network** and have the appropriate rights to connect to it. The instructions for setting up a target vary greatly between hardware providers, so consult your vendor documentation to configure your specific iSCSI target.
-=======
-It is assumed that **you already have an iSCSI target on your local network** and have the appropriate rights to connect to it. The instructions for setting up a target vary greatly between hardware providers, so consult your vendor documentation to configure your specific iSCSI target.*
->>>>>>> 2ee0225 (make the iscsi page compliant with the diataxis framework):how-to/storage/iscsi-initiator-or-client.md
-=======
-It is assumed that **you already have an iSCSI target on your local network** and have the appropriate rights to connect to it. The instructions for setting up a target vary greatly between hardware providers, so consult your vendor documentation to configure your specific iSCSI target.
->>>>>>> ab5e0bb (fix merge conflict)
 ```
 
 ## Network Interfaces Configuration

--- a/how-to/storage/iscsi-initiator-or-client.md
+++ b/how-to/storage/iscsi-initiator-or-client.md
@@ -15,14 +15,18 @@
 Ubuntu Server can be configured as both: **iSCSI initiator** and **iSCSI target**. This guide provides commands and configuration options to setup an **iSCSI initiator** (or Client).
 
 ```{note}
+<<<<<<< HEAD:explanation/storage/iscsi-initiator-or-client.md
 It is assumed that **you already have an iSCSI target on your local network** and have the appropriate rights to connect to it. The instructions for setting up a target vary greatly between hardware providers, so consult your vendor documentation to configure your specific iSCSI target.
+=======
+It is assumed that **you already have an iSCSI target on your local network** and have the appropriate rights to connect to it. The instructions for setting up a target vary greatly between hardware providers, so consult your vendor documentation to configure your specific iSCSI target.*
+>>>>>>> 2ee0225 (make the iscsi page compliant with the diataxis framework):how-to/storage/iscsi-initiator-or-client.md
 ```
 
 ## Network Interfaces Configuration
 
 Before start configuring iSCSI, make sure to have the network interfaces correctly set and configured in order to have open-iscsi package to behave appropriately, specially during boot time. In Ubuntu 20.04 LTS, the default network configuration tool is [netplan.io](https://netplan.readthedocs.io/en/latest/examples/).
 
-For all the iSCSI examples bellow please consider the following netplan configuration for my iSCSI initiator:
+For all the iSCSI examples below please consider the following netplan configuration for my iSCSI initiator:
 
 > */etc/cloud/cloud.cfg.d/99-disable-network-config.cfg*
 > ```

--- a/redirects.txt
+++ b/redirects.txt
@@ -440,7 +440,6 @@ about-logical-volume-management-lvm explanation/storage/about-lvm/
 
 service-iscsi how-to/storage/iscsi-initiator-or-client/
 iscsi-initiator-or-client how-to/storage/iscsi-initiator-or-client/
-explanation/storage/iscsi-initiator-or-client/ how-to/storage/iscsi-initiator-or-client/
 
 about-apt-upgrade-and-phased-updates explanation/software/about-apt-upgrade-and-phased-updates/
 

--- a/redirects.txt
+++ b/redirects.txt
@@ -438,8 +438,8 @@ troubleshooting-tls-ssl explanation/crypto/troubleshooting-tls-ssl/
 
 about-logical-volume-management-lvm explanation/storage/about-lvm/
 
-service-iscsi explanation/storage/iscsi-initiator-or-client/
-iscsi-initiator-or-client explanation/storage/iscsi-initiator-or-client/
+service-iscsi how-to/storage/iscsi-initiator-or-client/
+iscsi-initiator-or-client how-to/storage/iscsi-initiator-or-client/
 
 about-apt-upgrade-and-phased-updates explanation/software/about-apt-upgrade-and-phased-updates/
 

--- a/redirects.txt
+++ b/redirects.txt
@@ -440,6 +440,7 @@ about-logical-volume-management-lvm explanation/storage/about-lvm/
 
 service-iscsi how-to/storage/iscsi-initiator-or-client/
 iscsi-initiator-or-client how-to/storage/iscsi-initiator-or-client/
+explanation/storage/iscsi-initiator-or-client/ how-to/storage/iscsi-initiator-or-client/
 
 about-apt-upgrade-and-phased-updates explanation/software/about-apt-upgrade-and-phased-updates/
 


### PR DESCRIPTION
### Description

This PR makes the iSCSI page compliant with the diataxis framework

---

### Related Issue

- Fixes: #228

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
