### PR TITLE
Update observability.rst to correct outdated link

### DIFF
--- a/how-to/observability.rst
+++ b/how-to/observability.rst
@@ -4,7 +4,7 @@ Observability
 **************
 
 In Ubuntu, it is recommended to use the
-`Canonical Observability Stack <https://charmhub.io/topics/canonical-observability-stack>`_
+`Canonical Observability Stack <https://documentation.ubuntu.com/observability/>`_
 to monitor your infrastructure.
 
 However, you can also use the classic Logging, Monitoring and Alerting (LMA)


### PR DESCRIPTION
See above. Your link to the Canonical Observability Stack on that page is now outdated and is fixed in this pull request.

I would sign your contribution agreement, but I can't legally sign contracts in my country, unfortunately.

Sorry; if this PR is non-admissible, I completely understand.