### PR TITLE
Update user-management.md password policy to accurately reflect example

### DIFF
--- a/how-to/security/user-management.md
+++ b/how-to/security/user-management.md
@@ -161,7 +161,7 @@ By default, Ubuntu requires a minimum password length of 6 characters, as well a
 password        [success=1 default=ignore]      pam_unix.so obscure sha512
 ```
 
-To adjust the minimum length to 8 characters, change the appropriate variable to `min=8`. The modification is outlined below:
+To adjust the minimum length to 8 characters, change the appropriate variable to `minlen=8`. The modification is outlined below:
 
 ```text
 password        [success=1 default=ignore]      pam_unix.so obscure sha512 minlen=8


### PR DESCRIPTION
### Description

The docs reference an example where `/etc/pam.d/common-password` is modified to have a minimum length of 8 characters. This example references a `minlen=8` field when the explanation immediately above specifies the field as `min=8`.