### PR TITLE
[Update] Remove mentions of no-longer maintained or recommended observability tools and stacks.

### DIFF
--- a/how-to/observability.rst
+++ b/how-to/observability.rst
@@ -5,5 +5,8 @@ Observability
 
 In Ubuntu, it is recommended to use the
 `Canonical Observability Stack <https://documentation.ubuntu.com/observability/>`_
-to monitor your infrastructure. For more information about how to do this, see
-`the documentation on how to integrate COS Lite with uncharmed applications <https://documentation.ubuntu.com/observability/how-to/integrating-cos-lite-with-uncharmed-applications/>`_.
+to monitor your infrastructure. For more information, see the following links:
+
+- `Getting started with COS Lite <https://documentation.ubuntu.com/observability/tutorial/installation/getting-started-with-cos-lite/>`_
+- `How to integrate COS Lite with uncharmed applications <https://documentation.ubuntu.com/observability/how-to/integrating-cos-lite-with-uncharmed-applications/>`_
+- `The OpenTelemetry Collector snap <https://snapcraft.io/opentelemetry-collector>`_


### PR DESCRIPTION
Update the observability section to no longer talk about LMA, or mention outdated tooling. Instead, provide links to the COS documentation, and to the OpenTelemetry collector snap.