### PR TITLE
Document workaround for RTC issue on qemu-microvm

### DIFF
--- a/explanation/virtualisation/qemu-microvm.md
+++ b/explanation/virtualisation/qemu-microvm.md
@@ -171,7 +171,7 @@ For more details on what else could be disabled see
 Run the guest in `qemu-system-x86_64-microvm`:
 
 ```bash
-$ sudo qemu-system-x86_64-microvm -m 128M -machine accel=kvm \
+$ sudo qemu-system-x86_64-microvm -m 128M -machine accel=kvm,rtc=on \
     -bios /usr/share/qemu/qboot.rom \
     -kernel /boot/vmlinuz-$(uname -r) \
     -append 'console=ttyS0 root=/dev/vda fsck.mode=skip init=/usr/bin/hello' \


### PR DESCRIPTION
### Description

As documented in this bug[1] qboot doesn't support kvm-clock and microvm has RTC disabled by default. To workaround the qboot limitation, we can explicitly enable RTC with microvm.

[1] https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2074073

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors) (I work for Canonical)
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
