### PR TITLE
nvidia-drivers: hint how to determine ${DRIVER_BRANCH} for removal

### DIFF
--- a/how-to/graphics/install-nvidia-drivers.md
+++ b/how-to/graphics/install-nvidia-drivers.md
@@ -201,6 +201,7 @@ Remove any NVIDIA packages from your system:
 sudo apt --purge remove '*nvidia*${DRIVER_BRANCH}*'
 ```
 
+If you are unsure which `${DRIVER_BRANCH}` to pick for removal you might look at installed nvidia packages and see the different `${DRIVER_BRANCH}` on your system as numbers shared by several packges when you run `apt list --installed | grep nvidia`.
 Remove any additional packages that may have been installed as a dependency (e.g. the `i386` libraries on amd64 systems) and which were not caught by the previous command:
 
 ```bash

--- a/how-to/graphics/install-nvidia-drivers.md
+++ b/how-to/graphics/install-nvidia-drivers.md
@@ -201,7 +201,13 @@ Remove any NVIDIA packages from your system:
 sudo apt --purge remove '*nvidia*${DRIVER_BRANCH}*'
 ```
 
-If you are unsure which `${DRIVER_BRANCH}` to pick for removal you might look at installed nvidia packages and see the different `${DRIVER_BRANCH}` on your system as numbers shared by several packges when you run `apt list --installed | grep nvidia`.
+If you are unsure which `${DRIVER_BRANCH}` to pick for removal you might look at the installed nvidia packages and see the different `${DRIVER_BRANCH}` numbers that are present on your system.
+Since `autoremove` will take care of all indirect dependencies it is sufficient to list those that have been directly installed by using `apt-mark`.
+
+```bash
+apt-mark showmanual | grep nvidia`.
+```
+
 Remove any additional packages that may have been installed as a dependency (e.g. the `i386` libraries on amd64 systems) and which were not caught by the previous command:
 
 ```bash


### PR DESCRIPTION
Tooling does not automate selecting for removal, suggest how one can determine nvidia version numbers they might want to remove.

- Fixes: #275

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected (@renanrodrigo ran it on his system).