### PR TITLE
Fix readme links as shown on GH

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -25,11 +25,11 @@ with any page.
 * `Get support <https://ubuntu.com/support/community-support>`_
 * `Join the Discourse forum <https://discourse.ubuntu.com/c/server/17>`_
 * `Download Ubuntu Server <https://ubuntu.com/server>`_
-* :ref:`Find out how to contribute <contribute>`
+* `Find out how to contribute <https://documentation.ubuntu.com/server/contributing/>`_
 
 Offline version
 ===============
 
-You can :ref:`build this documentation locally <build-locally>`, or you can
+You can `build this documentation locally <https://documentation.ubuntu.com/server/contributing/build-locally>`_, or you can
 access `the PDF version <https://documentation.ubuntu.com/server/>`_ of this
 documentation from Read the Docs.


### PR DESCRIPTION
This isn't part of the rendered docs, but the readme shown on GH when navigating to the project - there two links are broken. Fix them by pointing them to the rendered pages matching the other external links on the page.

Spotted by Hector Cao, thanks!

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [n/a] My pull request is linked to an existing issue (was reported in a call, IMHO not worth a tracker).
- [x] I have tested my changes, and they work as expected.