### PR TITLE
Add sitemap extension and config

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -262,7 +262,8 @@ suppress_warnings = ['orphan']
 ## Sitemap configuration
 
 html_baseurl = 'https://documentation.ubuntu.com/server/'
-html_extra_path = ['_build/sitemap.xml']
+sitemap_url_scheme = "{link}"
+
 ############################################################
 ### PDF configuration
 ############################################################


### PR DESCRIPTION
### Description

Since the move to RTD we have discovered a problem with the RTD default setup in that Google can't access the RTD-created sitemaps as they're in the "wrong" location from Google's pov. This means the crawlers have a hard time discovering the sites - especially those under documentation.ubuntu.com, as it only crawls the site attached to that domain. All the sub-projects (of which Server docs are one) are ignored completely. This hurts our search rankings.

To solve this, we need to implement individual sitemaps per project, which the primary project can point to in its own sitemap.

**NOTE**: this is currently a WIP as we debug some issues.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [] I have tested my changes, and they work as expected.

