### PR TITLE
gnutls.md: clarify that /etc/gnutls/config exists after Noble

### DIFF
--- a/explanation/crypto/gnutls.md
+++ b/explanation/crypto/gnutls.md
@@ -1,8 +1,7 @@
 (gnutls)=
 # GnuTLS
 
-When initialised, the {term}`GnuTLS` library tries to read its system-wide configuration file
-`/etc/gnutls/config`. If the file doesn't exist, built-in defaults are used. To make configuration changes, the `/etc/gnutls` directory and the `config` file in it must be created manually, since they are not shipped in the Ubuntu packaging.
+When initialised, the {term}`GnuTLS` library tries to read its system-wide configuration file `/etc/gnutls/config`. This file is present in Ubuntu Noble 24.04 LTS and later, but previous releases did not ship it. In that case, if you want to make configuration changes, it has to be created manually.
 
 This config file can be used to disable (or mark as insecure) algorithms and
 protocols in a system-wide manner, overriding the library defaults. Note that,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Description

Clarify that `/etc/gnutls/config` does exist in Noble and later.

---

### Related Issue

- Fixes: #278 

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
