### PR TITLE
Removed AX and ArrayBolt from glossary

### DIFF
--- a/reference/glossary.rst
+++ b/reference/glossary.rst
@@ -123,9 +123,6 @@ A
 
         Related topic(s): :term:`IP` and :term:`LAN`.
 
-    ArrayBolt
-        *Work in Progress*
-
     async
         async stands for asynchronous. It is commonly used in programming to describe operations that take place without blocking the main execution thread. Instead of waiting for a particular operation to finish (such as reading a file or making a network request), 
         "async" programs can keep running other operations in the meantime. These operations are often dispatched to the background, allowing them to run in parallel. If needed, however, the program can still wait for the result of an asynchronous operation.
@@ -177,9 +174,6 @@ A
         See the `AWS documentation <https://docs.aws.amazon.com/>`_ for more details.
 
         Related topic(s): :term:`OpenStack`, Microsoft Azure, Google Cloud Platform (GCP), and IBM Cloud.
-
-    AX
-        *Work in Progress*
 
 .. _terms_B:
 


### PR DESCRIPTION
### Description

Removed the following terms from the glossary, as they are not in the docs:
- AX
- ArrayBolt

---

### Related Issue

This PR addresses [Issue #166 in the Open Documentation Academy repo](https://github.com/canonical/open-documentation-academy/issues/166).
Additionally, this is a follow-up PR based on prior review in PR #288.

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Checklist

- [X] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [X] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [X] My pull request is linked to an existing issue (if applicable).
- [X] I have tested my changes, and they work as expected.

---