### PR TITLE
OpenVPN: fix guide for Ubuntu 24.04+

### DIFF
--- a/how-to/security/install-openvpn.md
+++ b/how-to/security/install-openvpn.md
@@ -106,7 +106,16 @@ total 68
 -rw-r--r-- 1 root root 4141 2011-07-04 15:09 server.conf.gz
 ```
 
-Start by copying and unpacking `server.conf.gz` to `/etc/openvpn/server.conf`:
+Start by copying and unpacking `server.conf.gz` to `/etc/openvpn/server.conf`.
+
+In Ubuntu 24.04 or newer:
+
+```bash
+sudo cp /usr/share/doc/openvpn/examples/sample-config-files/server.conf /etc/openvpn/myserver.conf
+sudo gzip -d /etc/openvpn/myserver.conf.gz
+```
+
+In Ubuntu 23.04 or older:
 
 ```bash
 sudo cp /usr/share/doc/openvpn/examples/sample-config-files/server.conf.gz /etc/openvpn/myserver.conf.gz

--- a/how-to/security/install-openvpn.md
+++ b/how-to/security/install-openvpn.md
@@ -350,6 +350,7 @@ If the above didn't work for you, check the following:
 - Client and server must use same protocol and port, e.g. UDP port 1194, see `port` and `proto` config options.
 - Client and server must use the same compression configuration, see `comp-lzo` config option.
 - Client and server must use same config regarding bridged vs. routed mode, see `server vs server-bridge` config option
+- Client must use the config `tls-auth` with index `0` (example client config: `tls-auth FILE 0`), but server must use `tls-auth` with index `1` (example server config: `tls-auth FILE 1`).
 
 ## Advanced configuration
 

--- a/how-to/security/install-openvpn.md
+++ b/how-to/security/install-openvpn.md
@@ -129,6 +129,7 @@ ca ca.crt
 cert myservername.crt
 key myservername.key
 dh dh.pem
+tls-auth ./easy-rsa/ta.key 0
 ```
 
 Complete this set with a TLS Authentication (TA) key in `etc/openvpn` for `tls-auth` like this:

--- a/how-to/security/install-openvpn.md
+++ b/how-to/security/install-openvpn.md
@@ -135,7 +135,7 @@ tls-auth ./easy-rsa/ta.key 0
 Complete this set with a TLS Authentication (TA) key in `etc/openvpn` for `tls-auth` like this:
 
 ```bash
-sudo openvpn --genkey --secret ta.key
+sudo openvpn --genkey secret ta.key
 ```
 
 Edit `/etc/sysctl.conf` and uncomment the following line to enable IP forwarding:


### PR DESCRIPTION
### Description

Fix all the small issues described in #216 for OpenVPN in Ubuntu 24.04.

- Fix un-existing server.conf.gz
- Fix deprecated warning «`DEPRECATED OPTION: The option --secret is deprecated.`»
- Fix missing TLS Auth on the server

---

### Related Issue

- Fixes: #216

---

### Merge Strategy

I suggest to do **not** squash the commits, since each commit has meaningful details for the benefit of future 'git blame'. Therefore I suggest to merge as **fast-forward** (or merge commit). You're welcome! :+1: lol

---

### Checklist

- [X] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [X] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [X] My pull request is linked to an existing issue (if applicable).
- [X] I have tested my changes, and they work as expected.