### PR TITLE
debug-symbol sources in deb822 style

### DIFF
--- a/explanation/debugging/debug-symbol-packages.md
+++ b/explanation/debugging/debug-symbol-packages.md
@@ -31,10 +31,12 @@ sudo apt install ubuntu-dbgsym-keyring
 Create an `/etc/apt/sources.list.d/ddebs.list` by running the following line at a terminal:
 
 ```bash
-echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse
-deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse
-deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
-sudo tee -a /etc/apt/sources.list.d/ddebs.list
+echo "Types: deb
+URIs: http://ddebs.ubuntu.com/
+Suites: $(lsb_release -cs) $(lsb_release -cs)-updates $(lsb_release -cs)-proposed 
+Components: main restricted universe multiverse
+Signed-by: /usr/share/keyrings/ubuntu-dbgsym-keyring.gpg" | \
+sudo tee -a /etc/apt/sources.list.d/ddebs.sources
 ```
 
 You can also add these repositories in your software sources from the Ubuntu software center or from Synaptic (refer to [this article](https://help.ubuntu.com/community/Repositories/Ubuntu), especially the section on [adding other repositories](https://help.ubuntu.com/community/Repositories/Ubuntu#Adding_Other_Repositories)). You will need to add lines like:


### PR DESCRIPTION
Change to deb822 format sources file.
This works way back until >=Trusty and while people do not need it on newer systems, if they use it they would get apt complaining about outdated format.

Fixes: 301

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected (on bionic as it was the odlest I had around, but changelog say support since early 2014).