### PR TITLE
Add manpage role

### DIFF
--- a/.sphinx/spellingcheck.yaml
+++ b/.sphinx/spellingcheck.yaml
@@ -28,3 +28,5 @@ matrix:
       - img
       - a.p-navigation__link
       - a.contributor
+      - a.manpage.reference.external
+

--- a/contributing/writing-guidance.rst
+++ b/contributing/writing-guidance.rst
@@ -88,8 +88,8 @@ experience. In the Server Guide, we use the
 Language
 --------
 
-We use British (GB) English. It's a good idea to set your spellchecker to
-``en-GB``. We use an automated spelling checker that sometimes throws errors
+We use US English. It's a good idea to set your spellchecker to
+``en-US``. We use an automated spelling checker that sometimes throws errors
 about terms we would like it to ignore:
 
 - If it complains about a file name or a command, enclose the word in backticks
@@ -110,7 +110,10 @@ Acronyms should always be capitalised.
 They should always be expanded the first time they appear on a page, and then
 can be used as acronyms after that. E.g. YAML should be shown as Yet Another
 Markup Language (YAML), and then can be referred to as YAML for the rest of the
-page. 
+page.
+
+All acronyms should also be in our glossary -- you can add the term to the
+glossary if it is not present.
 
 Links
 -----
@@ -157,6 +160,30 @@ Avoid skipping header levels in your document structure, i.e., a level 2 header
 Always include some text between headers if you can. You can see this
 demonstrated between this section's heading and the one above it (Markdown
 elements). It looks quite odd without text to break the headers apart!
+
+Semantic markup
+---------------
+
+We encourage (but do not mandate) the use of semantic mark-up where possible.
+See `Roles <https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html>`_
+in the Sphinx documentation for an overview of inline semantic roles available
+by default. The most helpful ones for this project are:
+
+.. code-block::
+
+   Keyboard keys: {kbd}`Ctrl`, {kbd}`C`
+
+Rendered as :kbd:`Ctrl`, :kbd:`C`
+
+.. code-block::
+
+   Manpages: {manpage}`package-name(section)` (e.g. {manpage}`dpkg(1)`)
+
+Rendered as :manpage:`dpkg(1)`
+
+It is not necessary to provide the hardcoded URL to a manpage - they are
+generated when Sphinx rebuilds the documentation so that they are always up
+to date.
 
 Lists
 -----

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -147,6 +147,30 @@ linkcheck_ignore = [
 custom_linkcheck_anchors_ignore_for_url = []
 
 ############################################################
+### Manpages auto-linking
+############################################################
+
+# To enable manpage links, uncomment and replace {codename} with required
+# release, preferably an LTS release (e.g. noble). Do *not* substitute
+# {section} or {page}; these will be replaced by sphinx at build time
+#
+# NOTE: If set, adding '{manpage}' to an .md file adds a link to the
+# corresponding man section at the bottom of the page.
+#
+# manpages_url = 'https://manpages.ubuntu.com/manpages/{codename}/en/' + \
+#     'man{section}/{page}.{section}.html'
+
+stable_distro = "plucky"
+
+manpages_url = (
+    "https://manpages.ubuntu.com/manpages/"
+    + stable_distro
+    + "/en/man{section}/{page}.{section}.html"
+)
+
+
+
+############################################################
 ### Additions to default configuration
 ############################################################
 
@@ -192,6 +216,7 @@ custom_required_modules = [
     'sphinxext-rediraffe',
     'sphinx-hoverxref',
     'sphinx-sitemap',
+    'distro_info',
 ]
 
 # Configure hoverxref options

--- a/explanation/active-directory/identity-mapping-idmap-backends.md
+++ b/explanation/active-directory/identity-mapping-idmap-backends.md
@@ -4,13 +4,13 @@
 In order to have Domain users and groups from an Active Directory system appear in an Ubuntu system as valid, they need to have Linux specific attributes. Some of these attributes map directly to equivalent ones in Active Directory, some need to be translated to something else, and others do not exist at all. This is the problem that the Identity Mapping Backends (`idmap`) try to solve.
 
 There are basically three idmap backends to chose from:
-- [ad](https://manpages.ubuntu.com/manpages/noble/man8/idmap_ad.8.html): requires that Active Directory be augmented with RFC-2307 attributes
-- [rid](https://manpages.ubuntu.com/manpages/noble/man8/idmap_rid.8.html): algorithmic user/group id generation, manual domain configuration
-- [autorid](https://manpages.ubuntu.com/manpages/noble/man8/idmap_autorid.8.html): algorithmic user/group id generation, automatic domain configuration
+- {manpage}`idmap_ad(8)`: requires that Active Directory be augmented with RFC-2307 attributes
+- {manpage}`idmap_rid(8)`: algorithmic user/group id generation, manual domain configuration
+- {manpage}`idmap_autorid(8)`: algorithmic user/group ID generation, automatic domain configuration
 
-Of these, the simplest ones to use are *rid* and *autorid*, because they require no changes to Active Directory. These are the ones we will examine next.
+Of these, the simplest ones to use are `rid` and `autorid`, because they require no changes to Active Directory. These are the ones we will examine next.
 
-There is another idmap backend that we need to introduce, not related to Active Directory integration, but necessary in some cases: the *tdb* (Trivial Data Base) backend. The [idmap_tdb](https://manpages.ubuntu.com/manpages/noble/man8/idmap_tdb.8.html) backend is an *allocating backend* that stores the mappings on a persistent database on disk. It is needed whenever the mapping is not deterministic, and is instead done on a first come, first serve, order. Configurations using the *idmap_rid* backend need to be supported by the *idmap_tdb* backend as well, as will be shown later.
+There is another idmap backend that we need to introduce, not related to Active Directory integration, but necessary in some cases: the `tdb` (Trivial Data Base) backend. The {manpage}`idmap_tdb(8)` backend is an *allocating backend* that stores the mappings on a persistent database on disk. It is needed whenever the mapping is not deterministic, and is instead done on a first come, first serve, order. Configurations using the `idmap_rid` backend need to be supported by the `idmap_tdb` backend as well, as will be shown later.
 
 To better understand how these mapping mechanisms work, it helps to have a quick refresher on the typical [user ID ranges on an Ubuntu/Debian system](https://www.debian.org/doc/debian-policy/ch-opersys.html#uid-and-gid-classes):
 - `0-99`: builtin global allocations, shipped in the `base-passwd` package

--- a/explanation/active-directory/the-autorid-idmap-backend.md
+++ b/explanation/active-directory/the-autorid-idmap-backend.md
@@ -1,7 +1,7 @@
 (the-autorid-idmap-backend)=
 # The autorid idmap backend
 
-The [autorid](https://manpages.ubuntu.com/manpages/noble/man8/idmap_autorid.8.html) identity mapping backend, like the *rid* one, also provides an algorithmic mapping between SIDs and Linux IDs, with the advantage that it can also automatically cope with Active Directory deployed across multiple domains. There is no need to pre-allocate ranges for each specific existing or future domain. Some planning is required, though:
+The {manpage}`idmap_autorid(8)` identity mapping backend, like the `rid` one, also provides an algorithmic mapping between SIDs and Linux IDs, with the advantage that it can also automatically cope with Active Directory deployed across multiple domains. There is no need to pre-allocate ranges for each specific existing or future domain. Some planning is required, though:
 
 - range: the first and last ID that will be allocated on the Linux side by this backend. This includes all possible domains.
 - rangesize: how many IDs to allocate to each domain.
@@ -39,7 +39,7 @@ The `autorid.tdb` domain mapping database file is kept in `/var/lib/samba/` and 
 
 ## Pros and Cons of the autorid backend
 
-Let's examine the Pros and Cons of the *idmap_autorid* backend, and which scenarios are a better fit for it.
+Let's examine the Pros and Cons of the `idmap_autorid` backend, and which scenarios are a better fit for it.
 
 Pros:
 - automatic handling of trusted domains
@@ -49,7 +49,7 @@ Cons:
 - non-deterministic SID to ID mapping with multiple domains, even if the same idmap config settings are used for all domain-joined systems
 - extra concern to backup the domain mapping database file
 
-So when to use the *idmap_autorid* backend?
+So when to use the `idmap_autorid` backend?
 - Multiple domains are involved via trust relationships, and the stability of IDs is not required on the joined systems.
 - Single domain systems can also benefit from the easier and simpler up-front configuration.
 - If you need to share files owned by domain users via NFS or another mechanism which relies on stability of IDs, then this backend must not be used.

--- a/explanation/active-directory/the-rid-idmap-backend.md
+++ b/explanation/active-directory/the-rid-idmap-backend.md
@@ -1,7 +1,7 @@
 (the-rid-idmap-backend)=
 # The rid idmap backend
 
-The [rid](https://manpages.ubuntu.com/manpages/noble/man8/idmap_rid.8.html) idmap backend provides an algorithmic mapping between Linux uids/{term}`gids <GID>` and Active Directory SIDs. That means that a given SID will always map to the same uid/gid, and vice-versa, within the same domain.
+The {manpage}`idmap_rid(8)` idmap backend provides an algorithmic mapping between Linux uids/{term}`gids <GID>` and Active Directory SIDs. That means that a given SID will always map to the same uid/gid, and vice-versa, within the same domain.
 
 To use this backend, we have to choose two or more ID ranges:
 - a range for the domain we are joining

--- a/explanation/crypto/network-security-services-nss.md
+++ b/explanation/crypto/network-security-services-nss.md
@@ -141,7 +141,7 @@ This command will ask you for the NSS database password that you supplied when b
 * `-A`: Import a certificate.
 * `-a`: The certificate is in ASCII mode (PEM).
 * `-i localhost.pem`: The file to read (the actual certificate).
-* `-t TCP`: Trust flags (see the `-t trustargs` argument in the [certutil manpage](https://manpages.ubuntu.com/manpages/jammy/en/man1/certutil.1.html) for a full list).
+* `-t TCP`: Trust flags (see the `-t trustargs` argument in the {manpage}`certutil manpage <certutil(1)>` for a full list).
   * `T`: Trusted CA for client authentication.
   * `C`: Trusted CA.
   * `P`: Trusted peer.

--- a/explanation/crypto/openssh-crypto-configuration.md
+++ b/explanation/crypto/openssh-crypto-configuration.md
@@ -162,5 +162,5 @@ debug1: kex: client->server cipher: chacha20-poly1305@openssh.com MAC: <implicit
 ## References
 
 * [OpenSSH upstream documentation index](https://www.openssh.com/manual.html)
-* [Ubuntu `sshd_config` man page](https://manpages.ubuntu.com/manpages/jammy/man5/sshd_config.5.html)
-* [Ubuntu `ssh_config` man page](https://manpages.ubuntu.com/manpages/jammy/man5/ssh_config.5.html)
+* Ubuntu {manpage}`sshd_config(5)` manual page
+* Ubuntu {manpage}`ssh_config(5)` manual page

--- a/explanation/crypto/openssl.md
+++ b/explanation/crypto/openssl.md
@@ -7,7 +7,7 @@ The OpenSSL configuration file is located at `/etc/ssl/openssl.cnf` and is used 
 
 ## Structure of the config file
 
-The OpenSSL configuration file is very similar to a standard INI file. It starts with a nameless default section, not inside any `[section]` block, and after that we have the traditional `[section-name]` followed by the `key = value` lines. The [SSL config manpage](https://manpages.ubuntu.com/manpages/jammy/en/man5/config.5ssl.html) has all the details.
+The OpenSSL configuration file is very similar to a standard INI file. It starts with a nameless default section, not inside any `[section]` block, and after that we have the traditional `[section-name]` followed by the `key = value` lines. The [SSL config manpage](https://manpages.ubuntu.com/manpages/plucky/en/man5/config.5ssl.html) has all the details.
 
 This is what it looks like:
 
@@ -42,7 +42,7 @@ system_default = system_default_sect
 CipherString = DEFAULT:@SECLEVEL=2
 ```
 
-This gives us our first information about the default set of ciphers and algorithms used by OpenSSL in an Ubuntu installation: `DEFAULT:@SECLEVEL=2`. What that means is detailed inside the [SSL_CTX_set_security_level(3) manpage](https://manpages.ubuntu.com/manpages/jammy/en/man3/SSL_CTX_set_security_level.3ssl.html).
+This gives us our first information about the default set of ciphers and algorithms used by OpenSSL in an Ubuntu installation: `DEFAULT:@SECLEVEL=2`. What that means is detailed inside the {manpage}`SSL_CTX_set_security_level(3)` manpage.
 
 ```{note}
 In Ubuntu Jammy, TLS versions below 1.2 are **disabled** in OpenSSL's `SECLEVEL=2` due to [this patch](https://git.launchpad.net/ubuntu/+source/openssl/tree/debian/patches/tls1.2-min-seclevel2.patch?h=ubuntu/jammy-devel).
@@ -65,7 +65,7 @@ ECDHE-ECDSA-AES256-GCM-SHA384  TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(256)     
 The `openssl ciphers` command will output even ciphers that are not allowed, unless the `-s` switch is given. That option tells the command to list only **supported** ciphers.
 ```
 
-All the options that can be set in the `system_default_sect` section are detailed in the [SSL_CONF_cmd manpage](https://manpages.ubuntu.com/manpages/jammy/en/man3/SSL_CONF_cmd.3ssl.html#supported%20configuration%20file%20commands).
+All the options that can be set in the `system_default_sect` section are detailed in the {manpage}`SSL_CONF_cmd(3)` manpage.
 
 ## Cipher strings, cipher suites, cipher lists
 
@@ -311,4 +311,4 @@ New, TLSv1.2, Cipher is ECDHE-RSA-AES128-GCM-SHA256
   * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_security_level.html
   * https://www.feistyduck.com/library/openssl-cookbook/online/openssl-command-line/understanding-security-levels.html
 
-* [Configuration directives that can be used in the `system_default_sect` section](https://manpages.ubuntu.com/manpages/jammy/en/man3/SSL_CONF_cmd.3ssl.html#supported%20configuration%20file%20commands)
+* Configuration directives that can be used in the `system_default_sect` section are in the {manpage}`SSL_CONF_cmd(3)` manual page

--- a/explanation/crypto/troubleshooting-tls-ssl.md
+++ b/explanation/crypto/troubleshooting-tls-ssl.md
@@ -68,11 +68,11 @@ To use the tool, point it at the server you want to scan:
 $ sslscan j-server.lxd
 ```
 
-And you will get a report of the ciphers and algorithms supported by that server. [Consult its manpage](https://manpages.ubuntu.com/manpages/man1/sslscan.1.html) for more details.
+And you will get a report of the ciphers and algorithms supported by that server. Consult the {manpage}`sslscan(1)` manpage.
 
 ## References
 
-* [OpenSSL s_server](https://manpages.ubuntu.com/manpages/kinetic/en/man1/openssl-s_server.1ssl.html)
-* [OpenSSL s_client](https://manpages.ubuntu.com/manpages/kinetic/en/man1/openssl-s_client.1ssl.html)
-* [`sslscan`](https://manpages.ubuntu.com/manpages/man1/sslscan.1.html)
+* {manpage}`OpenSSL s_server <openssl-s_server(1)>`
+* {manpage}`OpenSSL s_client <openssl-s_client(1)>`
+* {manpage}`sslscan(1)`
 * [`https://badssl.com`](https://badssl.com/): excellent website that can be used to test a client against a multitude of certificates, algorithms, key sizes, protocol versions, and more.

--- a/explanation/dnssec/dnssec.md
+++ b/explanation/dnssec/dnssec.md
@@ -145,7 +145,7 @@ This is where the `trust-ad` setting from `/etc/resolv.conf` comes into play:
     nameserver 127.0.0.53
     options edns0 trust-ad
 
-The `trust-ad` setting is documented in the [resolv.conf(5)](https://manpages.ubuntu.com/manpages/noble/man5/resolv.conf.5.html) manpage. It means that the local resolver will:
+The `trust-ad` setting is documented in the {manpage}`resolv.conf(5)` manpage. It means that the local resolver will:
 
  * Set the `ad` bit (Authenticated Data) in the outgoing queries.
  * Trust the `ad` bit in the responses from the specified nameserver.

--- a/explanation/high-availability/pacemaker-fence-agents.md
+++ b/explanation/high-availability/pacemaker-fence-agents.md
@@ -66,7 +66,7 @@ $ pcs stonith create $RESOURCE_NAME fence_ipmilan \
 
 Where `$IP` is the IP address or {term}`hostname` of fencing device, `$PORT` is the TCP/UDP port to use for connection, `$USER` is the login name and `$PASSWD` its password, and `$ACTION` is the fencing actions which by default is `reboot`.
 
-This is one way to set up `fence_ipmilan`, for more information [refer to its manpage](https://manpages.ubuntu.com/manpages/en/man8/fence_ipmilan.8.html).
+This is one way to set up `fence_ipmilan`, for more information refer {manpage}`to its manpage <fence_ipmilan(8)>`.
 
 ## fence_mpath
 
@@ -120,7 +120,7 @@ One can do the same using `pcs` via the following command:
 $ pcs stonith create $RESOURCE_NAME fence_sbd devices=$DEVICE
 ```
 
-This is one way to set up `fence_sbd`, for more information [refer to its manpage](https://manpages.ubuntu.com/manpages/en/man8/fence_sbd.8.html).
+This is one way to set up `fence_sbd`, for more information refer {manpage}`to its manpage <fence_sbd(8)>`.
 
 ## fence_scsi
 
@@ -148,7 +148,7 @@ $ pcs stonith create $RESOURCE_NAME fence_scsi \
 
 The `pcmk_host_list` parameter contains a list of cluster nodes that can access the managed SCSI device.
 
-This is one way to set up `fence_scsi`, for more information [refer to its manpage](https://manpages.ubuntu.com/manpages/en/man8/fence_scsi.8.html).
+This is one way to set up `fence_scsi`, for more information refer {manpage}`to its manpage <fence_scsi(8)>`.
 
 ## fence_virsh
 
@@ -180,7 +180,7 @@ $ pcs stonith create $RESOURCE_NAME fence_virsh \
             use_sudo=true
 ```
 
-This is one way to set up `fence_virsh`, for more information [refer to its manpage](https://manpages.ubuntu.com/manpages/en/man8/fence_virsh.8.html).
+This is one way to set up `fence_virsh`, for more information refer {manpage}`to its manpage <fence_virsh(8)>`.
 
 In order to avoid running the resource in the same node that should be fenced, we need to add a location restriction:
 

--- a/explanation/high-availability/pacemaker-resource-agents.md
+++ b/explanation/high-availability/pacemaker-resource-agents.md
@@ -51,7 +51,7 @@ $ pcs resource create $RESOURCE_NAME ocf:heartbeat:IPaddr2 \
             op monitor interval=30s
 ```
 
-This is one way to set up `IPaddr2`, for more information [refer to its manpage](https://manpages.ubuntu.com/manpages/man7/ocf_heartbeat_IPaddr2.7.html).
+This is one way to set up `IPaddr2`, for more information refer {manpage}`to its manpage <ocf_heartbeat_IPaddr2(7)>`.
 
 ## iscsi
 
@@ -77,7 +77,7 @@ $ pcs resource create $RESOURCE_NAME ocf:heartbeat:iscsi \
 
 Where `$TARGET` is the iSCSI Qualified Name (IQN) of the iSCSI target and `$PORTAL` its address, which can be, for instance, formed by the IP address and port number used by the target daemon.
 
-This is one way to set up `iscsi`, for more information [refer to its manpage](https://manpages.ubuntu.com/manpages/en/man7/ocf_heartbeat_iscsi.7.html).
+This is one way to set up `iscsi`, for more information refer {manpage}`to its manpage <ocf_heartbeat_iscsi(7)>`.
 
 ## iSCSILogicalUnit
 
@@ -107,7 +107,7 @@ $ pcs resource create $RESOURCE_NAME ocf:heartbeat:iSCSILogicalUnit \
 
 Where implementation is set to `lio-t` as mentioned before, `$IQN_TARGET` is the iSCSI Qualified Name (IQN) that this Logical Unit belongs to, `$DEVICE` is the path to the exposed block device, and `$LUN` is the number representing the Logical Unit which will be exposed to initiators.
 
-This is one way to set up `iSCSILogicalUnit`, for more information [refer to its manpage](https://manpages.ubuntu.com/manpages/man7/ocf_heartbeat_iSCSILogicalUnit.7.html).
+This is one way to set up `iSCSILogicalUnit`, for more information refer {manpage}`to its manpage <ocf_heartbeat_iSCSILogicalUnit(7)>`.
 
 ## iSCSITarget
 
@@ -133,7 +133,7 @@ $ pcs resource create $RESOURCE_NAME ocf:heartbeat:iSCSITarget \
 
 Where implementation is set to `lio-t` as mentioned before and `$IQN_TARGET` is the IQN of the target.
 
-This is one way to set up `iSCSITarget`, for more information [refer to its manpage](https://manpages.ubuntu.com/manpages/man7/ocf_heartbeat_iSCSITarget.7.html).
+This is one way to set up `iSCSITarget`, for more information refer {manpage}`to its manpage <ocf_heartbeat_iSCSITarget(7)>`.
 
 ## LVM-activate
 
@@ -157,7 +157,7 @@ $ pcs resource create $RESOURCE_NAME ocf:heartbeat:LVM-activate \
              vg_access_mode=system_id
 ```
 
-This is one way to set up `LVM-activate`, for more information [refer to its manpage](https://manpages.ubuntu.com/manpages/en/man7/ocf_heartbeat_LVM-activate.7.html).
+This is one way to set up `LVM-activate`, for more information refer {manpage}`to its manpage <ocf_heartbeat_LVM-activate(7)>`.
 
 ## Systemd
 

--- a/explanation/intro-to/AD-integration.md
+++ b/explanation/intro-to/AD-integration.md
@@ -33,7 +33,7 @@ To set up your Active Directory integrations, we suggest first familiarising you
   - [rid identity mapping backend](https://wiki.samba.org/index.php/Idmap_config_rid)
   - [autorid identity mapping backend](https://wiki.samba.org/index.php/Idmap_config_autorid)
 - Manual pages:
-  - [idmap_tdb(8)](https://manpages.ubuntu.com/manpages/noble/man8/idmap_tdb.8.html)
-  - [idmap_rid(8)](https://manpages.ubuntu.com/manpages/noble/man8/idmap_rid.8.html)
-  - [idmap_autorid(8)](https://manpages.ubuntu.com/manpages/noble/man8/idmap_autorid.8.html)
-  - [wbinfo(1)](https://manpages.ubuntu.com/manpages/noble/en/man1/wbinfo.1.html)
+  - {manpage}`idmap_tdb(8)`
+  - {manpage}`idmap_rid(8)`
+  - {manpage}`idmap_autorid(8)`
+  - {manpage}`wbinfo(1)`

--- a/explanation/intro-to/high-availability.md
+++ b/explanation/intro-to/high-availability.md
@@ -134,7 +134,7 @@ Packages in this list aren't necessarily **HA** related packages, but they play 
   **CLVM** - supported before **Ubuntu 20.04**
 
   A distributed lock manager (DLM) is used to broker concurrent LVM metadata accesses. Whenever a cluster node needs to modify the LVM metadata, it must secure permission from its local  `clvmd` , which is in constant contact with other  `clvmd`  daemons in the cluster and can communicate a need to lock a particular set of objects.
-  **[lvmlockd](http://manpages.ubuntu.com/manpages/man8/lvmlockd.8.html)** - supported after **Ubuntu 20.04**
+  **{manpage}`lvmlockd(8)`** - supported after **Ubuntu 20.04**
   As of 2017, a stable LVM component that is designed to replace  `clvmd` by making the locking of LVM objects transparent to the rest of LVM, without relying on a distributed lock manager.
   The lvmlockd benefits over clvm are:
 

--- a/explanation/intro-to/wireguard-vpn.md
+++ b/explanation/intro-to/wireguard-vpn.md
@@ -3,7 +3,7 @@
 
 WireGuard is a simple, fast and modern VPN implementation. It is widely deployed and can be used cross-platform.
 
-VPNs have traditionally been hard to understand, configure and deploy. WireGuard removed most of that complexity by focusing on its single task, and leaving out things like key distribution and pushed configurations. You get a network interface which encrypts and verifies the traffic, and the remaining tasks like setting up addresses, routing, etc, are left to the usual system tools like [ip-route(8)](https://manpages.ubuntu.com/manpages/man8/ip-route.8.html) and [ip-address(8)](https://manpages.ubuntu.com/manpages/man8/ip-address.8.html).
+VPNs have traditionally been hard to understand, configure and deploy. WireGuard removed most of that complexity by focusing on its single task, and leaving out things like key distribution and pushed configurations. You get a network interface which encrypts and verifies the traffic, and the remaining tasks like setting up addresses, routing, etc, are left to the usual system tools like {manpage}`ip-route(8)` and {manpage}`ip-address(8)`.
 
 Setting up the cryptographic keys is very much similar to configuring SSH for key based authentication: each side of the connection has its own private and public key, and the peers' public key, and this is enough to start encrypting and verifying the exchanged traffic.
 
@@ -13,7 +13,7 @@ For more details on how WireGuard works, and information on its availability on 
 
 It helps to think of WireGuard primarily as a network interface, like any other. It will have the usual attributes, like IP address, CIDR, and there will be some routing associated with it. But it also has WireGuard-specific attributes, which handle the VPN part of things.
 
-All of this can be configured via different tools. WireGuard itself ships its own tools in the user-space package `wireguard-tools`: [`wg`](https://manpages.ubuntu.com/manpages/man8/wg.8.html) and [`wg-quick`](https://manpages.ubuntu.com/manpages/man8/wg-quick.8.html). But these are not strictly needed: any user space with the right privileges and kernel calls can configure a WireGuard interface. For example, `systemd-networkd` and `network-manager` can do it on their own, without the WireGuard user-space utilities.
+All of this can be configured via different tools. WireGuard itself ships its own tools in the user-space package `wireguard-tools`: {manpage}`wg(8)` and {manpage}`wg-quick(8)`. But these are not strictly needed: any user space with the right privileges and kernel calls can configure a WireGuard interface. For example, `systemd-networkd` and `network-manager` can do it on their own, without the WireGuard user-space utilities.
 
 Important attributes of a WireGuard interface are:
 
@@ -28,7 +28,7 @@ Important attributes of a WireGuard interface are:
 Cryptography is not simple. When we say that, for example, a private key is used to decrypt or sign traffic, and a public key is used to encrypt or verify the authenticity of traffic, this is a simplification and is hiding a lot of important details. WireGuard has a detailed explanation of its protocols and cryptography handling [on its website](https://www.wireguard.com/protocol/).
 ```
 
-These parameters can be set with the low-level [`wg`](https://manpages.ubuntu.com/manpages/man8/wg.8.html) tool, directly via the command line or with a configuration file. This tool, however, doesn't handle the non-WireGuard settings of the interface. It won't assign an IP address to it, for example, nor set up routing. For this reason, it's more common to use [`wg-quick`](https://manpages.ubuntu.com/manpages/man8/wg-quick.8.html).
+These parameters can be set with the low-level {manpage}`wg(8)` tool, directly via the command line or with a configuration file. This tool, however, doesn't handle the non-WireGuard settings of the interface. It won't assign an IP address to it, for example, nor set up routing. For this reason, it's more common to use {manpage}`wg-quick(8)`.
 
 `wg-quick` will handle the lifecycle of the WireGuard interface. It can bring it up or down, set up routing, execute arbitrary commands before or after the interface is up, and more. It augments the configuration file that `wg` can use, with its own extra settings, which is important to keep in mind when feeding that file to `wg`, as it will contain settings `wg` knows nothing about.
 
@@ -170,5 +170,6 @@ Throughout this guide, we will sometimes mention a VPN "connection". This is tec
 
 - See the [WireGuard website](https://www.wireguard.com) for more detailed information.
 - The [WireGuard Quickstart](https://www.wireguard.com/quickstart/) has a good introduction and demo.
-- [wg(8)](https://manpages.ubuntu.com/manpages/jammy/man8/wg.8.html) and [wg-quick(8)](https://manpages.ubuntu.com/manpages/jammy/man8/wg-quick.8.html) manual pages.
+- {manpage}`wg(8)` manual page
+- {manpage}`wg-quick(8)` manual page
 - [Detailed explanation](https://www.wireguard.com/protocol/) of the algorithms used by WireGuard.

--- a/explanation/multipath/configuring-multipath.md
+++ b/explanation/multipath/configuring-multipath.md
@@ -50,7 +50,7 @@ defaults {
 
 This overwrites the default value of the `user_friendly_names` parameter.
 
-All the multipath attributes that can be set in the `defaults` section of the `multipath.conf` file can be found [in the man pages](https://manpages.ubuntu.com/manpages/en/man5/multipath.conf.5.html#defaults%20section) with an explanation of what they mean. The attributes are:
+All the multipath attributes that can be set in the `defaults` section of the `multipath.conf` file can be found {manpage}`in the manual pages <multipath.conf(5)>` with an explanation of what they mean. The attributes are:
 
 * `verbosity`
 * `polling_interval`
@@ -191,7 +191,7 @@ The multipath subsection recognises the following attributes:
 
 ### Optional attributes
 
-The following attributes are optional; if not set, the default values are taken from the overrides, devices, or [defaults section](https://manpages.ubuntu.com/manpages/en/man5/multipath.conf.5.html#defaults%20section):
+The following attributes are optional; if not set, the default values are taken from the overrides, devices, or defaults section of the {manpage}`multipath.conf(5)` manual page:
 
  * `path_grouping_policy`
  * `path_selector`

--- a/explanation/networking/about-dhcp.md
+++ b/explanation/networking/about-dhcp.md
@@ -58,7 +58,7 @@ Ubuntu makes two DHCP servers available:
 
 - The [isc-dhcp-server Ubuntu Wiki](https://help.ubuntu.com/community/isc-dhcp-server) page has more information.
 
-- For more `/etc/dhcp/dhcpd.conf` options see the [dhcpd.conf man page](https://manpages.ubuntu.com/manpages/focal/en/man5/dhcpd.conf.5.html).
+- For more `/etc/dhcp/dhcpd.conf` options see the {manpage}`dhcpd.conf(5)` manual page
 
 - [ISC dhcp-server](https://www.isc.org/software/dhcp)
 

--- a/explanation/networking/configuring-networks.md
+++ b/explanation/networking/configuring-networks.md
@@ -358,7 +358,7 @@ The new bridge interface should now be up and running. The `brctl` provides usef
 
 Users of the former  `ifupdown` may be familiar with using hook scripts (e.g., pre-up, post-up) in their interfaces file. [Netplan configuration](https://netplan.readthedocs.io/en/stable/netplan-yaml/) does not currently support hook scripts in its configuration definition.
 
-Instead, to achieve this functionality with the `networkd` renderer, users can use [networkd-dispatcher](http://manpages.ubuntu.com/manpages/man8/networkd-dispatcher.8.html). The package provides both users and packages with hook points when specific network states are reached, to aid in reacting to network state.
+Instead, to achieve this functionality with the `networkd` renderer, users can use {manpage}`networkd-dispatcher(8)`. The package provides both users and packages with hook points when specific network states are reached, to aid in reacting to network state.
 
 ```{note}
 If you are on Desktop (not Ubuntu Server) the network is driven by Network Manager - in that case you need [NM Dispatcher scripts](https://developer.gnome.org/NetworkManager/unstable/NetworkManager.html) instead.
@@ -376,8 +376,8 @@ The [Netplan FAQ also has an example](https://netplan.io/faq/) on converting an 
 
   - The [Netplan website](https://netplan.io) has additional [examples](https://netplan.readthedocs.io/en/stable/netplan-yaml/#) and documentation.
 
-  - The [Netplan man page](https://manpages.ubuntu.com/manpages/man5/netplan.5.html) has more information on Netplan.
+  - The Netplan {manpage}`manual page <netplan(5)>` has more information on Netplan.
 
-  - The [systemd-resolved man page](https://manpages.ubuntu.com/manpages/man8/systemd-resolved.8.html) has more information on systemd-resolved service.
+  - The {manpage}`systemd-resolved(8)` manual page has more information on `systemd-resolved` service.
 
   - For more information on *bridging* see the [netplan.io examples page](https://netplan.readthedocs.io/en/stable/netplan-yaml/#properties-for-device-type-bridges)

--- a/explanation/networking/networking-key-concepts.md
+++ b/explanation/networking/networking-key-concepts.md
@@ -67,7 +67,7 @@ Daemons are special system applications which typically execute continuously in 
 
 ### Resources
 
-  - There are man pages for [TCP](https://manpages.ubuntu.com/manpages/focal/en/man7/tcp.7.html) and [IP](http://manpages.ubuntu.com/manpages/focal/man7/ip.7.html) that contain more useful information.
+  - There are manual pages for {manpage}`TCP <tcp(7)>` and {manpage}`IP <ip(7)>` that contain more useful information.
 
   - Also, see the [TCP/IP Tutorial and Technical Overview](http://www.redbooks.ibm.com/abstracts/gg243376.html) IBM Redbook.
 

--- a/explanation/performance/perf-tune-hwloc.md
+++ b/explanation/performance/perf-tune-hwloc.md
@@ -86,8 +86,7 @@ Core L#0
  cpukind info FrequencyBaseMHz = 1800
 ```
 
-See the [`hwloc-info`](https://manpages.ubuntu.com/manpages/noble/man1/hwloc-info.1.html)
-man page for a list of all the potential objects that can be queried.
+See the {manpage}`hwloc-info(1)` manual page for a list of all the potential objects that can be queried.
 
 ## hwloc-ls - system topology in CLI
 
@@ -213,6 +212,6 @@ Output (GUI):
 
 ## Further reading
 
-* [`hwloc-ls` man page](https://manpages.ubuntu.com/manpages/noble/en/man1/lstopo.1.html)
-* [`hwloc` man page](https://manpages.ubuntu.com/manpages/noble/en/man7/hwloc.7.html)
-* [`hwloc-diff` man page](https://manpages.ubuntu.com/manpages/noble/en/man1/hwloc-diff.1.html)
+* {manpage}`lstopo(1)` manual page
+* {manpage}`hwloc(7)` manual page
+* {manpage}`hwloc-diff(1)` manual page

--- a/explanation/performance/perf-tune-tuned.md
+++ b/explanation/performance/perf-tune-tuned.md
@@ -87,7 +87,7 @@ Here is a brief explanation of these configuration parameters:
 * `devices`: A comma separated list of device names (without the `/dev/` prefix) which represents the devices this plugin should act on. If not specified, all compatible devices found, now or in the future, will be used. This parameter also accepts simple globbing and negation rules, so that you can specify `nvme*` for all `/dev/nvme*` devices, or `!sda` to not include `/dev/sda`.
 * plugin-specific options: These can be seen in the output of the `tuned-adm list plugins -v` command, for each listed plugin.
 
-See the [tuned.conf manpage](https://manpages.ubuntu.com/manpages/noble/en/man5/tuned.conf.5.html) for details on the syntax of this configuration file.
+See the {manpage}`tuned.conf(5)` manpage for details on the syntax of this configuration file.
 
 The plugin instance concept can be useful if you want to apply different tuning parameters to diferent devices. For example, you could have one plugin instance to take care of NVMe storage, and another one for spinning disks:
 ```ini
@@ -246,12 +246,12 @@ The sections that follow `[main]` represent the configuration of tuning plugins.
 * Finally, the `sysctl` plugin is configured to set several variables in `sysfs` (the comments in the example explain the rationale behind each change).
 
 > \*1: This is a universe package
-> Ubuntu ships this software as part of its [universe repository](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/explanations/about_esm/#what-are-main-and-universe), which is maintained by volunteers from the Ubuntu community. Canonical also offers [Ubuntu Pro](https://ubuntu.com/pro) – a free-for-personal-use subscription that provides a 10 year [security maintenance commitment](https://ubuntu.com/security/esm).
+> Ubuntu ships this software as part of its [universe repository](https://documentation.ubuntu.com/pro-client/en/latest/explanations/about_esm/#what-are-main-and-universe), which is maintained by volunteers from the Ubuntu community. Canonical also offers [Ubuntu Pro](https://ubuntu.com/pro) – a free-for-personal-use subscription that provides a 10 year [security maintenance commitment](https://ubuntu.com/security/esm).
 
 ## Further reading
 
 * [TuneD website](https://tuned-project.org/)
-* [tuned-adm manpage](https://manpages.ubuntu.com/manpages/noble/en/man8/tuned-adm.8.html)
-* [TuneD profiles manpage](https://manpages.ubuntu.com/manpages/noble/en/man7/tuned-profiles.7.html)
-* [TuneD daemon manpage](https://manpages.ubuntu.com/manpages/noble/en/man8/tuned.8.html)
-* [TuneD configuration manpage](https://manpages.ubuntu.com/manpages/noble/en/man5/tuned.conf.5.html)
+* {manpage}`tuned-adm(8)` manpage
+* {manpage}`TuneD profiles <tuned-profiles(7)>` manpage
+* {manpage}`TuneD daemon <tuned(8)>` manpage
+* {manpage}`TuneD configuration <tuned.conf(5)>` manpage

--- a/explanation/security/security_suggestions.md
+++ b/explanation/security/security_suggestions.md
@@ -29,9 +29,7 @@ relevant for your setup.
    ```
 
    By default, `unattended-upgrade` runs daily, but this can be configured. See
-   the `unattended-upgrade`
-   [manual page](https://manpages.ubuntu.com/manpages/noble/en/man8/unattended-upgrades.8.html)
-   for details.
+   the {manpage}`unattended-upgrades(8)` manual page for details.
 
 1. **Manage your software**:
 
@@ -62,7 +60,7 @@ relevant for your setup.
    Most security patches can be fetched and applied automatically through the
    `unattended-upgrade` package. For more details on using and monitoring
    Ubuntu Pro via the command line, refer to the
-   [official documentation](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/).
+   [official documentation](https://documentation.ubuntu.com/pro-client/en/latest/).
 
 ### Access Control
 

--- a/explanation/software/about-apt-upgrade-and-phased-updates.md
+++ b/explanation/software/about-apt-upgrade-and-phased-updates.md
@@ -104,4 +104,4 @@ You can see the status of all packages currently being phased in Ubuntu at https
 
 - You can check on the progress of the current [phasing Ubuntu Stable Release Updates](https://people.canonical.com/~ubuntu-archive/phased-updates.html).
 
-- There is also more detail on how phased updates work in the [Ubuntu wiki](https://wiki.ubuntu.com/PhasedUpdates), the [Error Tracker](https://wiki.ubuntu.com/ErrorTracker/PhasedUpdates), and the [`apt` preferences manpage](https://manpages.ubuntu.com/manpages/jammy/man5/apt_preferences.5.html).
+- There is also more detail on how phased updates work in the [Ubuntu wiki](https://wiki.ubuntu.com/PhasedUpdates), the [Error Tracker](https://wiki.ubuntu.com/ErrorTracker/PhasedUpdates), and the {manpage}`apt preferences <apt_preferences(5)>` manpage.

--- a/explanation/software/changing-package-files.md
+++ b/explanation/software/changing-package-files.md
@@ -200,7 +200,7 @@ Configuration file '/etc/rsyslog.conf', does not exist on system.
 Installing new config file as you requested.
 ```
 
-More details on these options can be found in the [`dpkg` man page](https://manpages.ubuntu.com/manpages/jammy/en/man1/dpkg.1.html), but the most common and important ones are:
+More details on these options can be found in the {manpage}`dpkg(1)` manual page, but the most common and important ones are:
 
 * `confmiss`
    Always install the missing conffile without prompting.

--- a/how-to/backups/back-up-using-shell-scripts.md
+++ b/how-to/backups/back-up-using-shell-scripts.md
@@ -160,4 +160,4 @@ Once an archive has been created, it is important to test the archive. The archi
    
   - [`rsnapshot`](http://www.rsnapshot.org/): a file system snapshot utility used to create copies of an entire file system. Also check the {ref}`Tools - rsnapshot <install-rsnapshot>` for some information.
     
-  - [`rsync`](http://manpages.ubuntu.com/manpages/focal/man1/rsync.1.html): a flexible utility used to create incremental copies of files.
+  - {manpage}`rsync(1)`: a flexible utility used to create incremental copies of files.

--- a/how-to/backups/install-rsnapshot.md
+++ b/how-to/backups/install-rsnapshot.md
@@ -64,7 +64,7 @@ backup root@example.com:/etc/  example.com/    exclude=mtab,exclude=core
 
 As you can see, you can pass extra rsync parameters (the `+` appends the parameter to the default list -- if you remove the `+` sign you override it) and also exclude directories.
 
-You can check the comments in `/etc/rsnapshot.conf` and the [rsnapshot man page](http://manpages.ubuntu.com/manpages/focal/man1/rsnapshot.1.html) for more options.
+You can check the comments in `/etc/rsnapshot.conf` and the {manpage}`rsnapshot(1)` manual page for more options.
 
 ## Test configuration
 
@@ -107,5 +107,5 @@ For more information on how to schedule a backup using cron please take a look a
 ### Further reading
 
 * [rsnapshot offical web page](https://rsnapshot.org/)
-* [rsnapshot man page](http://manpages.ubuntu.com/manpages/focal/man1/rsnapshot.1.html)
-* [rsync man page](http://manpages.ubuntu.com/manpages/focal/man1/rsync.1.html)
+* {manpage}`rsnapshot(1)` manual page
+* {manpage}`rsync(1)` manual page

--- a/how-to/containers/lxd-containers.md
+++ b/how-to/containers/lxd-containers.md
@@ -232,7 +232,7 @@ For a full list of limits known to LXD, see [the configuration documentation](ht
 
 By default, LXD creates unprivileged containers. This means that root in the container is a non-root UID on the host. It is privileged against the resources owned by the container, but unprivileged with respect to the host, making root in a container roughly equivalent to an unprivileged user on the host. (The main exception is the increased attack surface exposed through the system call interface)
 
-Briefly, in an unprivileged container, 65536 UIDs are 'shifted' into the container. For instance, UID 0 in the container may be 100000 on the host, UID 1 in the container is 100001, etc, up to 165535. The starting value for UIDs and {term}`GIDs <GID>`, respectively, is determined by the 'root' entry the `/etc/subuid` and `/etc/subgid` files. (See the [subuid(5)](http://manpages.ubuntu.com/manpages/xenial/en/man5/subuid.5.html) man page.)
+Briefly, in an unprivileged container, 65536 UIDs are 'shifted' into the container. For instance, UID 0 in the container may be 100000 on the host, UID 1 in the container is 100001, etc, up to 165535. The starting value for UIDs and {term}`GIDs <GID>`, respectively, is determined by the 'root' entry the `/etc/subuid` and `/etc/subgid` files. (See the {manpage}`subuid(5)`) manual page.)
 
 It is possible to request a container to run without a UID mapping by setting the `security.privileged` flag to true:
 
@@ -254,7 +254,7 @@ All containers are confined by a default seccomp policy. This policy prevents so
 
 ## Raw LXC configuration
 
-LXD configures containers for the best balance of host safety and container usability. Whenever possible it is highly recommended to use the defaults, and use the LXD configuration keys to request LXD to modify as needed. Sometimes, however, it may be necessary to talk to the underlying lxc driver itself. This can be done by specifying LXC configuration items in the 'raw.lxc' LXD configuration key. These must be valid items as documented in [the lxc.container.conf(5) manual page](http://manpages.ubuntu.com/manpages/focal/en/man5/lxc.container.conf.5.html).
+LXD configures containers for the best balance of host safety and container usability. Whenever possible it is highly recommended to use the defaults, and use the LXD configuration keys to request LXD to modify as needed. Sometimes, however, it may be necessary to talk to the underlying lxc driver itself. This can be done by specifying LXC configuration items in the 'raw.lxc' LXD configuration key. These must be valid items as documented in the {manpage}`lxc.container.conf(5)` manual page.
 
 ### Snapshots
 

--- a/how-to/databases/install-postgresql.md
+++ b/how-to/databases/install-postgresql.md
@@ -170,6 +170,6 @@ PostgreSQL databases should be backed up regularly. Refer to the [PostgreSQL Adm
   sudo apt install postgresql-doc
   ```
 
-  This package provides further manpages on PostgreSQL  {term}`dblink` and "server programming interface" as well as the upstream HTML guide. To view the guide enter `xdg-open /usr/share/doc/postgresql-doc-*/html/index.html` or point your browser at it.
+  This package provides further manpages on PostgreSQL {term}`dblink` and "server programming interface" as well as the upstream HTML guide. To view the guide enter `xdg-open /usr/share/doc/postgresql-doc-*/html/index.html` or point your browser at it.
 
 - For general SQL information see the O'Reilly books [Getting Started with SQL: A Hands-On Approach for Beginners](http://shop.oreilly.com/product/0636920044994.do) by Thomas Nield as an entry point and [SQL in a Nutshell](http://shop.oreilly.com/product/9780596518851.do) as a quick reference.

--- a/how-to/high-availability/install-drbd.md
+++ b/how-to/high-availability/install-drbd.md
@@ -138,6 +138,6 @@ Using `ls` you should see `/srv/default` copied from the former primary host `dr
 
 - For more information on DRBD see the [DRBD web site](http://www.drbd.org/).
 
-- The [drbd.conf manpage](http://manpages.ubuntu.com/manpages/en/man5/drbd.conf.5.html) contains details on the options not covered in this guide.
+- The {manpage}`drbd.conf(5)` manual page contains details on the options not covered in this guide.
 
-- Also, see the [drbdadm manpage](http://manpages.ubuntu.com/manpages/en/man8/drbdadm.8.html).
+- Also, see the {manpage}`drbdadm(8)` manpage.

--- a/how-to/kerberos/install-a-kerberos-server.md
+++ b/how-to/kerberos/install-a-kerberos-server.md
@@ -87,7 +87,7 @@ You can also use a more generic form for this ACL:
 */admin@EXAMPLE.COM        *
 ```
 
-The above will grant all privileges to any admin instance of a principal. See the [`kadm5.acl` manpage](http://manpages.ubuntu.com/manpages/jammy/man5/kadm5.acl.5.html) for details.
+The above will grant all privileges to any admin instance of a principal. See the {manpage}`kadm5.acl(5)` manpage for details.
 
 Now restart the `krb5-admin-server` for the new ACL to take effect:
 

--- a/how-to/kerberos/kerberos-encryption-types.md
+++ b/how-to/kerberos/kerberos-encryption-types.md
@@ -165,6 +165,6 @@ MIT Kerberos has a [guide on updating encryption types](https://web.mit.edu/kerb
 * [Encryption types in MIT Kerberos](https://web.mit.edu/kerberos/krb5-latest/doc/admin/enctypes.html)
 * [`krb5.conf` encryption related configurations options](https://web.mit.edu/kerberos/krb5-latest/doc/admin/enctypes.html#configuration-variables)
 * [Migrating away from older encryption types](https://web.mit.edu/kerberos/krb5-latest/doc/admin/enctypes.html#migrating-away-from-older-encryption-types)
-* [`kdc.conf` manpage](https://manpages.ubuntu.com/manpages/jammy/man5/kdc.conf.5.html)
-* [`krb5.conf` manpage](https://manpages.ubuntu.com/manpages/jammy/man5/krb5.conf.5.html)
+* {manpage}`kdc.conf(5)` manpage
+* {manpage}`krb5.conf(5)` manpage
 * [Kerberos V5 concepts](https://web.mit.edu/kerberos/krb5-latest/doc/basic/index.html)

--- a/how-to/mail-services/install-exim4.md
+++ b/how-to/mail-services/install-exim4.md
@@ -267,7 +267,7 @@ sudo apt install cyrus-clients --no-install-recommends
 
 Here we are using the extra `--no-install-recommends` option because we don't need all the other components of the Cyrus email system.
 
-The tool we are interested in is called `smtptest`, and its documentation can be inspected in its manual page at [cyrus-smtptest](https://manpages.ubuntu.com/manpages/noble/man1/cyrus-smtptest.1.html).
+The tool we are interested in is called `smtptest`, and its documentation can be inspected in its manual page at {manpage}`cyrus-smtptest(1)`.
 
 For our purposes, we will run it like this, assuming an `ubuntu` user with the `ubuntusecret` password, and that the Exim4 server is running on the `n-exim.lxd` system:
 ```text

--- a/how-to/networking/chrony-client.md
+++ b/how-to/networking/chrony-client.md
@@ -138,7 +138,7 @@ The output produced will look something like this:
     Jun 02 11:27:09 questing systemd[1]: Started chrony.service - chrony, an NTP client/server.
 ```
 
-Default configuration such as `sourcedir`, `ntsdumpdir` or `rtcsync` is provided in `/etc/chrony/chrony.conf` and additional config files can be stored in `/etc/chrony/conf.d/`. The NTS servers from which to fetch time for `chrony` are in defined in `/etc/chrony/sources.d/ubuntu-ntp-pools.sources`. There are more advanced options documented in [man chrony.conf(5)](https://manpages.ubuntu.com/manpages/en/man5/chrony.conf.5.html). Common use cases are specifying an explicit trusted certificate. After changing any part of the config file you need to restart `chrony`, as follows:
+Default configuration such as `sourcedir`, `ntsdumpdir` or `rtcsync` is provided in `/etc/chrony/chrony.conf` and additional config files can be stored in `/etc/chrony/conf.d/`. The NTS servers from which to fetch time for `chrony` are in defined in `/etc/chrony/sources.d/ubuntu-ntp-pools.sources`. There are more advanced options documented in the {manpage}`chrony.conf(5)` manpage. Common use cases are specifying an explicit trusted certificate. After changing any part of the config file you need to restart `chrony`, as follows:
 
 ```bash
 sudo systemctl restart chrony.service
@@ -150,8 +150,8 @@ If you would now like to also serve the Network Time Protocol via `chrony`, this
 
 ## References
 
-- [Manpage about chronyc](https://manpages.ubuntu.com/manpages/man1/chronyc.1.html)
+- {manpage}`chronyc(1)` manual page
 
-- [Manpage about chronyd](https://manpages.ubuntu.com/manpages/man8/chronyd.8.html)
+- {manpage}`chronyd(8)` manual page
 
-- [Manpage about chrony.conf](https://manpages.ubuntu.com/manpages/man5/chrony.conf.5.html)
+- {manpage}`chrony.conf(5)` manual page

--- a/how-to/networking/dnssec-troubleshooting.md
+++ b/how-to/networking/dnssec-troubleshooting.md
@@ -255,6 +255,5 @@ There are some public third-party web-based tools that will check the status of 
 ## Further reading
 
  * [bind9's guide to DNSSEC troubleshooting](https://bind9.readthedocs.io/en/latest/dnssec-guide.html#basic-dnssec-troubleshooting)
- * [`delv` manpage](https://manpages.ubuntu.com/manpages/noble/man1/delv.1.html)
- * [`dig` manpage](https://manpages.ubuntu.com/manpages/noble/man1/delv.1.html)
-
+ * {manpage}`delv(1)` manpage
+ * {manpage}`dig(1)` manpage

--- a/how-to/networking/install-dnssec.md
+++ b/how-to/networking/install-dnssec.md
@@ -186,5 +186,5 @@ Taking that line, the actual record to send to the parent zone just needs a litt
  * [Easy-Start Guide for Signing Authoritative Zones](https://bind9.readthedocs.io/en/stable/dnssec-guide.html#signing)
  * [Creating a Custom DNSSEC Policy](https://bind9.readthedocs.io/en/stable/dnssec-guide.html#signing-custom-policy)
  * [Detailed DNSSEC chapter from the bind9 documentation](https://bind9.readthedocs.io/en/stable/chapter5.html)
- * [`delv` manual page](https://manpages.ubuntu.com/manpages/noble/man1/delv.1.html)
+ * {manpage}`delv(1)` manual page
  * [Working with the parent zone](https://bind9.readthedocs.io/en/latest/dnssec-guide.html#working-with-the-parent-zone)

--- a/how-to/networking/install-isc-dhcp-server.md
+++ b/how-to/networking/install-isc-dhcp-server.md
@@ -58,6 +58,6 @@ sudo systemctl restart isc-dhcp-server.service
 
 - The [isc-dhcp-server Ubuntu Wiki](https://help.ubuntu.com/community/isc-dhcp-server) page has more information.
 
-- For more `/etc/dhcp/dhcpd.conf` options see the [dhcpd.conf man page](https://manpages.ubuntu.com/manpages/focal/en/man5/dhcpd.conf.5.html).
+- For more `/etc/dhcp/dhcpd.conf` options see the {manpage}`dhcpd.conf(5)` manual page
 
 - [ISC dhcp-server](https://www.isc.org/software/dhcp)

--- a/how-to/networking/install-nfs.md
+++ b/how-to/networking/install-nfs.md
@@ -78,9 +78,9 @@ NFS is comprised of several services, both on the server and the client. Each on
 
 ### Ubuntu Server 22.04 LTS ("jammy")
 
-All NFS related services read a single configuration file: `/etc/nfs.conf`. This is a INI-style config file, see the [`nfs.conf(5)`](http://manpages.ubuntu.com/manpages/jammy/man5/nfs.conf.5.html) manpage for details. Furthermore, there is a `/etc/nfs.conf.d` directory which can hold `*.conf` snippets that can override settings from previous snippets or from the `nfs.conf` main config file itself.
+All NFS related services read a single configuration file: `/etc/nfs.conf`. This is a INI-style config file, see the {manpage}`nfs.conf(5)` manual page for details. Furthermore, there is a `/etc/nfs.conf.d` directory which can hold `*.conf` snippets that can override settings from previous snippets or from the `nfs.conf` main config file itself.
 
-There is a new command-line tool called [`nfsconf(8)`](http://manpages.ubuntu.com/manpages/jammy/man8/nfsconf.8.html) which can be used to query or even set configuration parameters in `nfs.conf`. In particular, it has a `--dump` parameter which will show the effective configuration including all changes done by `/etc/nfs.conf.d/*.conf` snippets.
+There is a new command-line tool called {manpage}`nfsconf(8)` which can be used to query or even set configuration parameters in `nfs.conf`. In particular, it has a `--dump` parameter which will show the effective configuration including all changes done by `/etc/nfs.conf.d/*.conf` snippets.
 
 ### For Ubuntu Server 20.04 LTS ("focal") and earlier
 
@@ -129,7 +129,7 @@ For example, `systemctl restart nfs-server.service` will restart `nfs-mountd`, `
 
 Of course, each service can still be individually restarted with the usual `systemctl restart <service>`.
 
-The [`nfs.systemd(7)`](http://manpages.ubuntu.com/manpages/jammy/man7/nfs.systemd.7.html) manpage has more details on the several systemd units available with the NFS packages.
+The {manpage}`nfs.systemd(7)` manpage has more details on the several systemd units available with the NFS packages.
 
 
 ## NFS with Kerberos
@@ -191,7 +191,7 @@ Refresh the exports:
     $ sudo exportfs -rav
     exporting *:/storage
 
-The security options are explained in the [`exports(5)`](http://manpages.ubuntu.com/manpages/jammy/man5/exports.5.html) manpage, but generally they are:
+The security options are explained in the {manpage}`exports(5)` manpage, but generally they are:
   - `krb5`: use kerberos for authentication only (non-auth traffic is in clear text)
   - `krb5i`: use kerberos for authentication and integrity checks (non-auth traffic is in clear text)
   - `krb5p`: use kerberos for authentication, integrity and privacy protection (non-auth traffic is encrypted)

--- a/how-to/networking/serve-ntp-with-chrony.md
+++ b/how-to/networking/serve-ntp-with-chrony.md
@@ -34,7 +34,7 @@ An example would be:
 allow 1.2.3.4
 ```
 
-See the section "NTP server" in the [man page](http://manpages.ubuntu.com/manpages/jammy/man5/chrony.conf.5.html) for more details on how you can control and restrict access to your NTP server.
+See the section "NTP server" in the {manpage}`chrony.conf(5)` manual page for more details on how you can control and restrict access to your NTP server.
 
 ## View `chrony` status
 
@@ -322,7 +322,7 @@ This provides output in the following form:
     ...
 ```
 
-For more complex scenarios there are many more advanced options for configuring NTS. These are documented in [the `chrony` man page](https://manpages.ubuntu.com/manpages/en/man5/chrony.conf.5.html).
+For more complex scenarios there are many more advanced options for configuring NTS. These are documented in the {manpage}`chrony.conf(5)` manual page.
 
 ```{note} *About certificate placement*
 

--- a/how-to/observability/install-logwatch.md
+++ b/how-to/observability/install-logwatch.md
@@ -144,4 +144,4 @@ Filesystem      Size  Used Avail Use% Mounted on
 ```
 
 ## Further reading
-- The [Ubuntu manpage for Logwatch](https://manpages.ubuntu.com/manpages/en/man8/logwatch.8.html) contains many more detailed options.
+- The Ubuntu {manpage}`logwatch(8)` manpage contains many more detailed options.

--- a/how-to/openldap/access-control.md
+++ b/how-to/openldap/access-control.md
@@ -114,5 +114,5 @@ See how to {ref}`set up LDAP users and groups <ldap-users-and-groups>`.
 
 ## Further reading
 
-- See the man page for [slapd.access](http://manpages.ubuntu.com/manpages/slapd.access.html).
+- See the manual page for {manpage}`slapd.access(5)`
 - The [access control topic](https://openldap.org/doc/admin25/guide.html#Access%20Control) in the OpenLDAP administrator's guide.

--- a/how-to/openldap/install-openldap.md
+++ b/how-to/openldap/install-openldap.md
@@ -334,7 +334,7 @@ If the schema you want to add does not exist in LDIF format, a nice conversion t
 
 Activity logging for `slapd` is very useful when implementing an OpenLDAP-based solution -- and it must be manually enabled after software installation. Otherwise, only rudimentary messages will appear in the logs. Logging, like any other such configuration, is enabled via the `slapd-config` database.
 
-OpenLDAP comes with multiple logging levels, with each level containing the lower one (additive). A good level to try is **stats**. The [slapd-config man page](https://manpages.ubuntu.com/manpages/slapd-config.html) has more to say on the different subsystems.
+OpenLDAP comes with multiple logging levels, with each level containing the lower one (additive). A good level to try is **stats**. The {manpage}`slapd-config(5)` manual page has more to say on the different subsystems.
 
 ### Example logging with the stats level 
 

--- a/how-to/openldap/replication.md
+++ b/how-to/openldap/replication.md
@@ -123,7 +123,7 @@ olcSpSessionLog: 100
 
 ```{warning}
 The LDIF above has some parameters that you should review before deploying in production on your directory. In particular -- `olcSpCheckpoint` and `olcSpSessionLog`.
-Please see the [slapo-syncprov(5) man page](http://manpages.ubuntu.com/manpages/man5/slapo-syncprov.5.html). In general, `olcSpSessionLog` should be equal to (or preferably larger than) the number of entries in your directory. Also see [ITS #8125](https://www.openldap.org/its/index.cgi/?findid=8125) for details on an existing bug.
+Please see the {manpage}`slapo-syncprov(5)` manual page. In general, `olcSpSessionLog` should be equal to (or preferably larger than) the number of entries in your directory. Also see [ITS #8125](https://www.openldap.org/its/index.cgi/?findid=8125) for details on an existing bug.
 ```
 
 Add the new content:
@@ -264,8 +264,8 @@ olcAccessLogPurge: 07+00:00 01+00:00
 
 ```{warning}
 The LDIF above has some parameters that you should review before deploying in production on your directory. In particular -- `olcSpCheckpoint`, `olcSpSessionLog`.
-Please see the [slapo-syncprov(5) manpage](http://manpages.ubuntu.com/manpages/man5/slapo-syncprov.5.html). In general, `olcSpSessionLog` should be equal to (or preferably larger than) the number of entries in your directory. Also see [ITS #8125](https://www.openldap.org/its/index.cgi/?findid=8125) for details on an existing bug.
-For `olcAccessLogPurge`, please check the [slapo-accesslog(5) manpage](http://manpages.ubuntu.com/manpages/man5/slapo-accesslog.5.html).
+Please see the {manpage}`slapo-syncprov(5)` manpage. In general, `olcSpSessionLog` should be equal to (or preferably larger than) the number of entries in your directory. Also see [ITS #8125](https://www.openldap.org/its/index.cgi/?findid=8125) for details on an existing bug.
+For `olcAccessLogPurge`, please check the {manpage}`slapo-accesslog(5)` manpage.
 ```
 
 Create a directory:

--- a/how-to/samba/member-server-in-an-ad-domain.md
+++ b/how-to/samba/member-server-in-an-ad-domain.md
@@ -112,7 +112,7 @@ Until [bug #1980246](https://bugs.launchpad.net/ubuntu/+source/realmd/+bug/19802
 
 When domain users and groups are brought to the Linux world, a bit of translation needs to happen, and sometimes new values need to be created. For example, there is no concept of a "login shell" for AD users, but it exists in Linux.
 
-The following are some common `/etc/samba/smb.conf` options you are likely to want to tweak in your installation. The [`smb.conf(5)` man page](https://manpages.ubuntu.com/manpages/jammy/man5/smb.conf.5.html) explains the `%` variable substitutions and other details:
+The following are some common `/etc/samba/smb.conf` options you are likely to want to tweak in your installation. The {manpage}`smb.conf(5)` manual page explains the `%` variable substitutions and other details:
 
 - **home directory** 
 `template homedir = /home/%U@%D`
@@ -199,11 +199,11 @@ You can also restrict access to the share as usual. Just keep in mind the syntax
 
 User and group identifiers on the AD side are not directly usable as identifiers on the Linux site. A *mapping* needs to be performed.
 
-Winbind supports several `idmap` backends, and each one has its own man page. The three main ones are:
+Winbind supports several `idmap` backends, and each one has its own manual page. The three main ones are:
 
-- [`idmap_ad`](https://manpages.ubuntu.com/manpages/jammy/man8/idmap_ad.8.html)
-- [`idmap_autorid`](https://manpages.ubuntu.com/manpages/jammy/man8/idmap_autorid.8.html)
-- [`idmap_rid`](https://manpages.ubuntu.com/manpages/jammy/man8/idmap_rid.8.html)
+- {manpage}`idmap_ad(8)`
+- {manpage}`idmap_autorid(8)`
+- {manpage}`idmap_rid(8)`
 
 Choosing the correct backend for each deployment type needs careful planing. Upstream has some guidelines at [Choosing an `idmap` backend](https://wiki.samba.org/index.php/Setting_up_Samba_as_a_Domain_Member#Choosing_an_idmap_backend), and each man page has more details and recommendations.
 

--- a/how-to/samba/mount-cifs-shares-permanently.md
+++ b/how-to/samba/mount-cifs-shares-permanently.md
@@ -165,7 +165,7 @@ If you get the error "mount error(13) permission denied", then the server denied
 * Are you using a valid username and password? Does that account really have access to this folder?
 * Do you have blank space in your credentials file? It should be `password=mspassword`, not `password = mspassword`.
 * Do you need a domain? For example, if you are told that your username is `SALES\sally`, then actually your username is `sally` and your domain is `SALES`. You can add a `domain=SALES` line to the `~/.credentials` file.
-* The security and version settings are interrelated. SMB1 is insecure and no longer supported. At first, try to not specify either security or version: do not specify `sec=` or `vers=`. If you still have authentication errors then you may need to specify either `sec=` or `vers=` or both. You can try the options listed at the [mount.cifs man page](https://manpages.ubuntu.com/manpages/en/man8/mount.cifs.8.html).
+* The security and version settings are interrelated. SMB1 is insecure and no longer supported. At first, try to not specify either security or version: do not specify `sec=` or `vers=`. If you still have authentication errors then you may need to specify either `sec=` or `vers=` or both. You can try the options listed at the {manpage}`mount.cifs(8)` manual page.
 
 ### Mount after login instead of boot
 

--- a/how-to/samba/provision-samba-ad-controller.md
+++ b/how-to/samba/provision-samba-ad-controller.md
@@ -257,7 +257,7 @@ This Samba AD/DC server can be treated as an Active Directory server for Window 
 ## References
 
 - [Active Directory Domain Services Overview](https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/get-started/virtual-dc/active-directory-domain-services-overview)
-- [`samba-tool` manual page](https://manpages.ubuntu.com/manpages/noble/man8/samba-tool.8.html)
+- {manpage}`samba-tool(8)` manual page
 - Active Directory integration:
   - {ref}`Choosing an integration method <choosing-an-integration-method>`
   - {ref}`Joining a Member Server <join-a-domain-with-winbind-preparation>`

--- a/how-to/samba/share-access-controls.md
+++ b/how-to/samba/share-access-controls.md
@@ -97,7 +97,7 @@ sudo setfacl -R -m g:qa:rx /srv/samba/share/
 The `setfacl` command above gives *execute* permissions to all files in the `/srv/samba/share` directory, which you may or may not want.
 ```
 
-Now from a Windows client you should notice the new file permissions are implemented. See [the `acl`](https://manpages.ubuntu.com/manpages/trusty/man5/acl.5.html) and [`setfacl`](https://manpages.ubuntu.com/manpages/trusty/man1/setfacl.1.html) man pages for more information on POSIX ACLs.
+Now from a Windows client you should notice the new file permissions are implemented. See the {manpage}`acl(5)` and {manpage}`setfacl(1)` manual pages for more information on POSIX ACLs.
 
 ## Further reading
 

--- a/how-to/security/firewalls.md
+++ b/how-to/security/firewalls.md
@@ -9,7 +9,7 @@ The kernel's packet filtering system would be of little use to administrators wi
 
 The default firewall configuration tool for Ubuntu is `ufw`. Developed to ease `iptables` firewall configuration, `ufw` provides a user-friendly way to create an IPv4 or IPv6 host-based firewall.
 
-`ufw` by default is initially disabled. From the [`ufw` man page](https://manpages.ubuntu.com/manpages/en/man8/ufw.8.html):
+`ufw` by default is initially disabled. From the {manpage}`ufw(8)` manual page:
 
 > ufw is not intended to provide complete firewall functionality via its command interface, but instead provides an easy way to add or remove simple rules. It is currently mainly used for host-based firewalls.
 
@@ -118,7 +118,7 @@ sudo ufw status verbose
 If the port you want to open or close is defined in `/etc/services`, you can use the port name instead of the number. In the above examples, replace `22` with `ssh`.
 ```
 
-This is a quick introduction to using `ufw`. Please refer to the [`ufw` man page](https://manpages.ubuntu.com/manpages/en/man8/ufw.8.html) for more information.
+This is a quick introduction to using `ufw`. Please refer to the {manpage}`ufw(8)` manual page for more information.
 
 ### ufw application integration
 
@@ -164,7 +164,7 @@ ubuntu-bug nameofpackage
 
 The purpose of IP masquerading is to allow machines with private, non-routable IP addresses on your network to access the Internet through the machine doing the masquerading. Traffic from your private network destined for the Internet must be manipulated for replies to be routable back to the machine that made the request.
 
-To do this, the kernel must modify the **source** IP address of each packet so that replies will be routed back to it, rather than to the private IP address that made the request, which is impossible over the Internet. Linux uses **Connection Tracking** ([`conntrack`](https://manpages.ubuntu.com/manpages/en/man8/conntrack.8.html)) to keep track of which connections belong to which machines and reroute each return packet accordingly. Traffic leaving your private network is thus "masqueraded" as having originated from your Ubuntu gateway machine. This process is referred to in Microsoft documentation as "Internet Connection Sharing".
+To do this, the kernel must modify the **source** IP address of each packet so that replies will be routed back to it, rather than to the private IP address that made the request, which is impossible over the Internet. Linux uses **Connection Tracking** ({manpage}`conntrack(8)`) to keep track of which connections belong to which machines and reroute each return packet accordingly. Traffic leaving your private network is thus "masqueraded" as having originated from your Ubuntu gateway machine. This process is referred to in Microsoft documentation as "Internet Connection Sharing".
 
 ### IP masquerading with ufw
 
@@ -324,7 +324,7 @@ There are many tools available to help you construct a complete firewall without
 
 - The [Ubuntu Firewall](https://wiki.ubuntu.com/UncomplicatedFirewall) wiki page contains information on the development of ufw
 
-- Also, the [`ufw` manual page](https://manpages.ubuntu.com/manpages/en/man8/ufw.8.html) contains some very useful information: `man ufw`
+- Also, the {manpage}`ufw(8)` manual page contains some very useful information: `man ufw`
 
 - See the [packet-filtering-HOWTO](http://www.netfilter.org/documentation/HOWTO/packet-filtering-HOWTO.html) for more information on using `iptables`
 

--- a/how-to/security/openssh-server.md
+++ b/how-to/security/openssh-server.md
@@ -26,7 +26,7 @@ sudo apt install openssh-server
 
 ## Configure OpenSSH
 
-To configure the default behavior of the OpenSSH server application, `sshd`, edit the file `/etc/ssh/sshd_config`. For information about the configuration directives used in this file, refer [to the online manpage](https://manpages.ubuntu.com/manpages/man5/sshd_config.5.html) or run `man sshd_config` at a terminal prompt.
+To configure the default behavior of the OpenSSH server application, `sshd`, edit the file `/etc/ssh/sshd_config`. For information about the configuration directives used in this file, refer to the online {manpage}`sshd_config(5)` manpage or run `man sshd_config` at a terminal prompt.
 
 There are many directives in the `sshd` configuration file, which control things like communication settings and authentication modes. The following are examples of configuration directives that can be changed by editing the `/etc/ssh/sshd_config` file.
 

--- a/how-to/security/smart-card-authentication.md
+++ b/how-to/security/smart-card-authentication.md
@@ -217,7 +217,7 @@ services = pam
 pam_cert_auth = True
 ```
 
-Further `[pam]` configuration options can be changed accroding to [`man sssd.conf`](https://manpages.ubuntu.com/manpages/jammy/en/man5/sssd.conf.5.html#services%20sections).
+Further `[pam]` configuration options can be changed according to the {manpage}`sssd.conf(5)` manual page.
 
 ### Configure SSSD Certificate Authorities database
 
@@ -277,7 +277,7 @@ The sss PAM module allows certificates to be used for login, though our Linux sy
 
 For the purposes of this guide, we will use a simple local user mapping as reference.
 
-Mapping for more complex configurations can be done following the official [SSSD documentation](https://sssd.io/design-pages/matching_and_mapping_certificates.html) depending on [providers](https://sssd.io/design-pages/certmaps_for_LDAP_AD_file.html). For up-to-date information on certificate mapping, please also consult the [sss-certmap](https://manpages.ubuntu.com/manpages/jammy/en/man5/sss-certmap.5.html) manpage.
+Mapping for more complex configurations can be done following the official [SSSD documentation](https://sssd.io/design-pages/matching_and_mapping_certificates.html) depending on [providers](https://sssd.io/design-pages/certmaps_for_LDAP_AD_file.html). For up-to-date information on certificate mapping, please also consult the {manpage}`sss-certmap(5)` manpage.
 
 #### Local users mapping
 

--- a/how-to/security/user-management.md
+++ b/how-to/security/user-management.md
@@ -34,7 +34,7 @@ To disable the root account password, use the following `passwd` syntax:
 sudo passwd -l root
 ```
 
-You can learn more about `sudo` by reading the [`sudo` man page](https://manpages.ubuntu.com/manpages/man8/sudo.8.html): `man sudo`
+You can learn more about `sudo` by reading the {manpage}`sudo(8)` manual page: `man sudo`
 
 By default, the initial user created by the Ubuntu installer is a member of the group `sudo` which is added to the file `/etc/sudoers` as an authorised `sudo` user. To give any other account full root access through `sudo`, add them to the `sudo` group.
 

--- a/how-to/software/automatic-updates.md
+++ b/how-to/software/automatic-updates.md
@@ -58,7 +58,7 @@ In many cases this is beneficial, but in some cases it might be counter-producti
 Persistent=false
 ```
 
-With this change, the timer will trigger the service only on the next scheduled time. In other words, it won't catch up to the run it missed while the system was off. See the explanation for the *Persistent* option in [systemd.timer manpage](https://manpages.ubuntu.com/manpages/noble/en/man5/systemd.timer.5.html) for more details.
+With this change, the timer will trigger the service only on the next scheduled time. In other words, it won't catch up to the run it missed while the system was off. See the explanation for the *Persistent* option in {manpage}`systemd.timer(5)` manpage for more details.
 
 ## Where to pick updates from
 
@@ -209,7 +209,7 @@ Besides logging, `unattended-upgrades` can also send out reports via email. Ther
    - `on-change`: Only send a report if upgrades were applied. This is the default value.
 
 ```{note}
-Sending out emails like this requires the separate configuration of a package like [ssmtp](https://manpages.ubuntu.com/manpages/noble/man8/ssmtp.8.html) or another minimalistic mail client that is capable of sending messages to a mail server.
+Sending out emails like this requires the separate configuration of a package like {manpage}`ssmtp(8)` or another minimalistic mail client that is capable of sending messages to a mail server.
 ```
 
 ### Notification examples
@@ -293,10 +293,10 @@ Reboots can be very disruptive, especially if the system fails to come back. The
 
  * `Unattended-Upgrade::Automatic-Reboot "false";`: If this option is set to `true`, the system will be rebooted ***without confirmation*** at the end of an upgrade run if a reboot was requested. The default value is `false`.
  * `Unattended-Upgrade::Automatic-Reboot-WithUsers "true";`: Automatically reboot even if there are users currently logged in when `Unattended-Upgrade::Automatic-Reboot` (the option above) is set to `true`. The default value is `true`.
- * `Unattended-Upgrade::Automatic-Reboot-Time "now";`: If automatic reboot is enabled and needed, reboot at the specific time instead of immediately. The time value is passed as-is to the [shutdown](https://manpages.ubuntu.com/manpages/noble/en/man8/shutdown.8.html) command. It can be the text "now" (which is the default), or in the format "hh:mm" (hours:minutes), or an offset in minutes specified like "+m". Note that if using "hh:mm", it will be in the local system's timezone.
+ * `Unattended-Upgrade::Automatic-Reboot-Time "now";`: If automatic reboot is enabled and needed, reboot at the specific time instead of immediately. The time value is passed as-is to the {manpage}`shutdown(8)` command. It can be the text "now" (which is the default), or in the format "hh:mm" (hours:minutes), or an offset in minutes specified like "+m". Note that if using "hh:mm", it will be in the local system's timezone.
 
 ```{note}
-For more information about this time specification for the reboot, and other options like cancelling a scheduled reboot, see the [shutdown manpage](https://manpages.ubuntu.com/manpages/noble/en/man8/shutdown.8.html).
+For more information about this time specification for the reboot, and other options like cancelling a scheduled reboot, see the {manpage}`shutdown(8)` manpage.
 ```
 
 Below are the logs of an `unattended-upgrades` run that started at 20:43. The tool installed the available upgrades and detected that a reboot was requested, which was scheduled using the configured `Automatic-Reboot-Time` (20:45 in this example):
@@ -374,7 +374,7 @@ On other environments, such as Ubuntu Server, you can implement your own prompti
 
 
 ## Testing and troubleshooting
-It's possible to test some configuration changes to `unattended-upgrade` without having to wait for the next time it would run. The `unattended-upgrade` tool has a [manual page](https://manpages.ubuntu.com/manpages/noble/man8/unattended-upgrade.8.html) that explains all its command-line options. Here are the most useful ones for testing and troubleshooting:
+It's possible to test some configuration changes to `unattended-upgrade` without having to wait for the next time it would run. The `unattended-upgrade` tool has a {manpage}`manual page <unattended-upgrade(8)>` that explains all its command-line options. Here are the most useful ones for testing and troubleshooting:
 
  * `-v`: Show a more verbose output.
  * `--dry-run`:  Just simulate what would happen, without actually making any changes.

--- a/how-to/software/package-management.md
+++ b/how-to/software/package-management.md
@@ -133,7 +133,7 @@ To remove the same package, you would use the command:
 sudo aptitude remove nmap
 ```
 
-Consult the [Aptitude manpages](https://manpages.ubuntu.com/manpages/man8/aptitude-curses.8.html) for full details of Aptitude's command-line options.
+Consult the {manpage}`Aptitude manpages <aptitude-curses(8)>` for full details of Aptitude's command-line options.
 
 ## dpkg
 
@@ -200,7 +200,7 @@ sudo dpkg -r zip
 Uninstalling packages using `dpkg`, is **NOT** recommended in most cases. It is better to use a package manager that handles dependencies to ensure that the system is left in a consistent state. For example, using `dpkg -r zip` will remove the `zip` package, but any packages that depend on it will still be installed and may no longer function correctly as a result.
 ```
 
-For more `dpkg` options see the [`dpkg` manpage](https://manpages.ubuntu.com/manpages/en/man1/dpkg.1.html): `man dpkg`.
+For more `dpkg` options see the {manpage}`dpkg(1)` manpage: `man dpkg`.
 
 ## APT configuration
 
@@ -265,6 +265,6 @@ Most of the material covered in this chapter is available in the respective man 
 
 - The [Installing Software](https://help.ubuntu.com/community/InstallingSoftware) Ubuntu wiki page has more information.
 - The [APT User's Guide](https://www.debian.org/doc/user-manuals#apt-guide) contains useful information regarding APT usage.
-- For more information about systemd timer units (and systemd in general), visit the [systemd man page](https://manpages.ubuntu.com/manpages/en/man1/systemd.1.html) and [systemd.timer man page](https://manpages.ubuntu.com/manpages/en/man5/systemd.timer.5.html).
+- For more information about systemd timer units (and systemd in general), visit the {manpage}`systemd(1)` manual page and {manpage}`systemd.timer(5)` manual page
 - See the [Aptitude user's manual](https://www.debian.org/doc/user-manuals#aptitude-guide) for more Aptitude options.
 - The [Adding Repositories HOWTO (Ubuntu Wiki)](https://help.ubuntu.com/community/Repositories/Ubuntu) page contains more details on adding repositories.

--- a/how-to/software/report-a-bug.md
+++ b/how-to/software/report-a-bug.md
@@ -68,7 +68,7 @@ Choices:
 Please choose (1/C):  1
 ```
     
-The browser that will be used when choosing '1' will be the one known on the system as `www-browser` via the [Debian alternatives system](https://manpages.ubuntu.com/manpages/en/man1/update-alternatives.1.html). Examples of text-based browsers to install include links, {term}`ELinks`, lynx, and w3m. You can also manually point an existing browser at the given URL.
+The browser that will be used when choosing '1' will be the one known on the system as `www-browser` via the {manpage}`Debian alternatives system <update-alternatives(1)>`. Examples of text-based browsers to install include links, {term}`ELinks`, lynx, and w3m. You can also manually point an existing browser at the given URL.
 
 ### V: View
 

--- a/how-to/virtualisation/cloud-image-vms-with-uvtool.md
+++ b/how-to/virtualisation/cloud-image-vms-with-uvtool.md
@@ -159,7 +159,7 @@ Some other parameters will have an impact on the cloud-init configuration:
 
 - `--packages <package_list>` : Install the comma-separated packages specified in `package_list` on first boot.
 
-A complete description of all available modifiers is available in the [`uvt-kvm` manpages](https://manpages.ubuntu.com/manpages/lunar/en/man1/uvt-kvm.1.html).
+A complete description of all available modifiers is available in the {manpage}`uvt-kvm(1)` manpages.
 
 ## Resources
 

--- a/how-to/virtualisation/qemu.md
+++ b/how-to/virtualisation/qemu.md
@@ -58,7 +58,7 @@ These tools can do much more, as you'll discover in their respective (long) [man
 qemu-system-x86_64 options image[s]
 ```
 
-So take a look at the [QEMU manpage](http://manpages.ubuntu.com/manpages/bionic/man1/qemu-system.1.html), [`qemu-img`](http://manpages.ubuntu.com/manpages/bionic/man1/qemu-img.1.html) and the [QEMU documentation](https://www.qemu.org/documentation/) and see which options best suit your needs.
+So take a look at the {manpage}`QEMU manpage <qemu-system(1)>`, {manpage}`qemu-img(1)` and the [QEMU documentation](https://www.qemu.org/documentation/) and see which options best suit your needs.
 
 While a standard QEMU configuration works for most use cases, some scenarios demand high-vCPU VMs. In the next section, we’ll cover how to create QEMU virtual machines with up to 1024 vCPUs.
 

--- a/how-to/virtualisation/virtual-machine-manager.md
+++ b/how-to/virtualisation/virtual-machine-manager.md
@@ -114,7 +114,7 @@ virt-install \
    --vcpus=4
 ```
 
-There are many more arguments that can be found in the [`virt-install` manpage](https://manpages.ubuntu.com/manpages/jammy/man1/virt-install.1.html). However, here is an explanation of arguments used in the example above, one by one:
+There are many more arguments that can be found in the {manpage}`virt-install(1)` manpage. However, here is an explanation of arguments used in the example above, one by one:
 
 * `--name web_devel`:
    The name of the new virtual machine will be `web_devel`.

--- a/how-to/wireguard-vpn/common-tasks.md
+++ b/how-to/wireguard-vpn/common-tasks.md
@@ -41,7 +41,7 @@ We can add this `PostUp` command to the `home0.conf` configuration file to have 
 PostUp = resolvectl dns %i 10.10.10.1; resolvectl domain %i \~home
 ```
 
-For `PostUp` (and `PostDown` -- see the [`wg-quick(8)` manpage](https://manpages.ubuntu.com/manpages/en/man8/wg-quick.8.html) for details), the `%i` text is replaced with the WireGuard interface name. In this case, that would be `home0`.
+For `PostUp` (and `PostDown` -- see the {manpage}`wg-quick(8)` manpage for details), the `%i` text is replaced with the WireGuard interface name. In this case, that would be `home0`.
 
 These two `resolvectl` commands tell the local *systemd-resolved* resolver to:
 * associate the DNS server at `10.10.10.1` to the `home0` interface, and
@@ -74,7 +74,7 @@ Current DNS Server: 10.10.10.1
 If you are using `systemctl` to control the WireGuard interface, this is the type of change (adding or changing `PostUp`) where the `reload` action won't be enough, and you actually need to issue a `restart`.
 
 ```{note}
-The [`wg-quick(8)` manpage](https://manpages.ubuntu.com/manpages/en/man8/wg-quick.8.html) documents the DNS setting of the WireGuard interface which has the same purpose, but only works if you have `resolveconf` installed. Ubuntu systems by default don't, and rely on `systemd-resolved` instead.
+The {manpage}`wg-quick(8)` manpage documents the DNS setting of the WireGuard interface which has the same purpose, but only works if you have `resolveconf` installed. Ubuntu systems by default don't, and rely on `systemd-resolved` instead.
 ```
 
 ## Adding another peer

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -39,7 +39,7 @@ Access Control List
     specific operation.
 
     See also:
-    * [the ACL manual page](https://manpages.ubuntu.com/manpages/noble/man5/acl.5.html)
+    * {manpage}`the ACL manual page <acl(5)>`
 
     Related topic(s):
     * Security, {term}`OpenLDAP`, and {term}`Kerberos`
@@ -1241,7 +1241,7 @@ journald
     containers. 
 
     See also:
-    * [the `journald.conf` manual page](https://manpages.ubuntu.com/manpages/noble/man5/journald.conf.5.html/)
+    * The {manpage}`journald.conf(5)` manual page
     * [Docker `journald` documentation](https://docs.docker.com/engine/logging/drivers/journald/) for details on using journald as a logging driver
 
     Related topic(s):

--- a/reference/other-tools/pam-motd.md
+++ b/reference/other-tools/pam-motd.md
@@ -64,6 +64,6 @@ You should now be greeted with some useful information, and some information abo
 
 ## Resources
 
-  - See the [update-motd man page](http://manpages.ubuntu.com/manpages/jammy/en/man5/update-motd.5.html) for more options available to update-motd.
+  - See the {manpage}`update-motd(5)` manual page for more options available to update-motd.
 
   - The Debian Package of the Day [weather](http://debaday.debian.net/2007/10/04/weather-check-weather-conditions-and-forecasts-on-the-command-line/) article has more details about using the weatherutility.

--- a/tutorial/managing-software.rst
+++ b/tutorial/managing-software.rst
@@ -651,8 +651,8 @@ or later, we'll want to customise the package so that it better fits our own
 purposes.
 
 Before we try to customise the package, we should probably look at what files
-are included in it. We can check this using ``dpkg``, which is the
-`Debian package manager <https://manpages.ubuntu.com/manpages/en/man1/dpkg.1.html>`_.
+are included in it. We can check this using :manpage:`dpkg(1)`, which is the
+Debian package manager.
 Although APT is now more commonly used for basic package handling, ``dpkg``
 retains some really helpful commands for examining files and finding out
 package information. It's installed by default on Ubuntu systems so we can use


### PR DESCRIPTION
### Description

This PR adds the "manpage" role, so that instead of providing hardcoded links to the manpages (which go out of date frequently), the manpages are auto-rendered off the most recent stable version of the manpages (which we still have to update, but at least it's only one place - the conf file)

Now, if you need to reference a manpage, the syntax is as follows:
```
{manpage}`pkg-name(section-number)`
```

By using this, all our manpage links will automatically generated when Sphinx builds so they will be up to date (instead of referring back to really old hardcoded releases)

(I will add docs for this to the contributing guide before merging)

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

