### PR TITLE
gitolite: rewrite for current configuration and best practices

### DIFF
--- a/how-to/backups/install-gitolite.md
+++ b/how-to/backups/install-gitolite.md
@@ -1,11 +1,20 @@
 (install-gitolite)=
-# How to install and configure gitolite
+# How to set up gitolite
 
-{term}`Gitolite` provides a traditional source control management server for git, with multiple users and access rights management. 
+{term}`Gitolite` Gitolite allows you to setup git hosting on a central server, with fine-grained access control and many more powerful features.
+
+You can use your served repositories as `git remote` in the form of `git@yourserver:some/repo/path`.
+
+Gitolite stores ["bare git"](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefbarerepositoryabarerepository) repositories at a location of your choice, usually `/home/git`.
+It has its independent user realm, each user is created by assigning their {term}`SSH-key`.
+The repos itself are owned by one system user of your choice, usually `git`.
 
 ## Install a gitolite server
 
-Gitolite can be installed with the following command:
+Gitolite can be installed with the following command.
+
+The install automation will ask for a path or content of your `admin` ssh key.
+For a better understanding of your setup we recommend to leave the prompt empty for full control of your setup (so you can use `git` as the username, and customize the storage path).
 
 ```bash
 sudo apt install gitolite3
@@ -13,81 +22,127 @@ sudo apt install gitolite3
 
 ## Configure gitolite
 
-Configuration of the gitolite server is a little different that most other servers on Unix-like systems, in that gitolite stores its configuration in a git repository rather than in files in `/etc/`. The first step to configuring a new installation is to allow access to the configuration repository.
+Gitolite stores its configuration in a git repository (called `gitolite-admin`), so there's no configuration in `/etc`.
+This configuration repository manages all other git repos, users and their permissions.
 
-First of all, let's create a user for gitolite to use for the service:
-
-```bash
-sudo adduser --system --shell /bin/bash --group --disabled-password --home /home/git git
-```
-
-Now we want to let gitolite know about the repository administrator's public SSH key. This assumes that the current user is the repository administrator. If you have not yet configured an SSH key, refer to the section on {ref}`SSH keys in our OpenSSH guide <openssh-server>`.
+Create a `git` user for gitolite to use for the service (you can adjust the git repo storage path as the `--home` directory):
 
 ```bash
-cp ~/.ssh/id_rsa.pub /tmp/$(whoami).pub
+sudo useradd --system --home /home/git git
 ```
 
-Let's switch to the git user and import the administrator's key into gitolite.
+To access the config repository, we now add the administrator's public {term}`SSH-key`.
+If you have not yet configured an SSH key, refer to the section on {ref}`SSH keys in our OpenSSH guide <openssh-server>`.
+
+We copy it to `/tmp` so our `git` user can read the file to import it.
+Please adjust the path to the desired admin user's {term}`SSH-key` (and algorithm, like `id_rsa.pub`).
+
 
 ```bash
-sudo su - git
-gl-setup /tmp/*.pub
+cp ~/.ssh/id_ed25519.pub /tmp/admin.pub
 ```
 
-Gitolite will allow you to make initial changes to its configuration file during the setup process. You can now clone and modify the gitolite configuration repository from your administrator user (the user whose public SSH key you imported). Switch back to that user, then clone the configuration repository:
+As the `git` user, let's import the administrator's key into gitolite (it will get the `admin` username due to that key's filename).
 
 ```bash
-exit
-git clone git@$IP_ADDRESS:gitolite-admin.git
-cd gitolite-admin
+sudo -i -u git gitolite setup -pk /tmp/admin.pub
 ```
 
-The `gitolite-admin` contains two subdirectories:
+What this creates:
+- the management repo in `~git/repositories/gitolite-admin.git`
+- a global config in `~git/.gitolite.rc`
+- `~git/projects.list` as repo overview
+- `~git/.ssh/authorized_keys` with `command=` to force gitolite over `ssh`
+  - later it will contain the `ssh` public key for each user you configured
 
-- **`conf`** : contains the configuration files
-- **`keydir`** : contains the list of user's public SSH keys
+To try if the setup worked, try `ssh` as the user owning the admin key we just added, so see the _gitolite repo overview_:
+
+```bash
+ssh git@yourserver
+```
+```
+hello admin, this is git@your-gitolite-server running gitolite3
+
+ R W	gitolite-admin
+ R W	testing
+```
+
 
 ## Managing gitolite users and repositories
 
-Adding a new user to gitolite is simple: just obtain their public SSH key and add it to the `keydir` directory as `$DESIRED_USER_NAME.pub`. Note that the gitolite usernames don't have to match the system usernames - they are only used in the gitolite configuration file to manage access control. 
+To configure gitolite users, repositories and permissions, clone the configuration repository.
+`$yourserver` can be an ip-address, hostname, or just `localhost` for your current machine.
 
-Similarly, users are deleted by deleting their public key files. After each change, do not forget to commit the changes to git, and push the changes back to the server with:
+```bash
+git clone git@$yourserver:gitolite-admin.git
+```
+
+To apply configuration change, commit them in the repo and **push the changes** back to the server with:
 
 ```bash
 git commit -a
 git push origin master
 ```
 
-Repositories are managed by editing the `conf/gitolite.conf` file. The syntax is space-separated, and specifies the list of repositories followed by some access rules. The following is a default example:
+The `gitolite-admin` contains two subdirectories: **`keydir`** (which contains the list of users' public SSH keys) and **`conf`** (which contains configuration files).
+To **add a gitolite user** (it's virtual - not a system username), obtain their SSH public key (from `~user/.ssh/id_<name>.pub`) and add it to the `keydir` directory as `<desired-username>.pub`.
+To **delete a gitolite user**, you only need to delete their public key files.
+To manage repositories and groups in `conf/gitolite.conf`, specify the the list of repositories followed by some access rules.
+
+
+Have an example:
 
 ```text
+# gitolite config
+# users are created by their public key in keydir/$username.pub
+
+# group creation
+@bestproject          = name1 name2
+@projectwatchers      = name3 @bestproject
+
+# this repo itself
 repo    gitolite-admin
         RW+     =   admin
         R       =   alice
-    
-repo    project1
-        RW+     =   alice
-        RW      =   bob
-        R       =   denise
+
+# a repo with access to anybody
+repo    testing
+        RW+     = @all
+
+# a repo with special privileges, to tags and branches
+repo    some/awesome/project
+        RW                      =   alice @bestproject
+        RW+                     =   bob
+        RW+   dev/              =   @bestproject
+        R                       =   @projectwatchers carol
+# bestproject members and alice can push code (but not force-push)
+# bestproject members can force-push branches starting with dev/
+# bob can forcepush anything
+# projectwatchers and carol have readonly access
 ```
+
+For more advanced permission configuration (restricting tags, branches, ...), please see the examples in the upstream documentation [page 1](https://gitolite.com/gitolite/conf.html) and [page 2](https://gitolite.com/gitolite/conf-2.html).
+
 
 ## Using your server
 
-Once a user's public key has been imported by the gitolite admin, granting the user authorisation to use one or more repositories, the user can access those repositories with the following command:
+Now you can use your newly set up gitolite server as a regular `git remote`.
 
+Once a user is created and has permissions, they can access the repositories.
+
+As a fresh clone:
 ```bash
-git clone git@$SERVER_IP:$PROJECT_NAME.git
+git clone git@$server:some/awesome/project.git
 ```
 
-To add the server as a new remote for an existing git repository:
-
+Or as a remote to an existing repository:
 ```bash
-git remote add gitolite git@$SERVER_IP:$PROJECT_NAME.git
+git remote add gitolite git@$server:some/awesome/project.git
 ```
 
 ## Further reading
 
 - [Gitolite's code repository](https://github.com/sitaramc/gitolite) provides access to source code
-- [Gitolite's documentation](https://gitolite.com/gitolite/) includes a "fool-proof setup" guide and a cookbook with recipes for common tasks
+- [Gitolite's documentation](https://gitolite.com/gitolite/) includes more detailed configuration guides and a "fool-proof setup", with how-tos for common tasks
 - Gitolite's maintainer has written a book, [Gitolite Essentials](https://www.packtpub.com/hardware-and-creative/gitolite-essentials), for more in-depth information about the software
-- General information about git itself can be found at the [Git homepage](http://git-scm.com)
+- General information about `git` itself can be found at the [Git homepage](http://git-scm.com)

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -885,7 +885,7 @@ Group ID
     * Active Directory integration, Samba, Security, SSSD
 
 gitolite
-    Gitolite is a tool installed on a central server for managing git
+    [Gitolite](../how-to/backups/install-gitolite.md) is a tool installed on a central server for managing git
     repositories and controlling access to them, all via the command line. The
     central server becomes a git server.
 

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -885,7 +885,7 @@ Group ID
     * Active Directory integration, Samba, Security, SSSD
 
 gitolite
-    [Gitolite](../how-to/backups/install-gitolite.md) is a tool installed on a central server for managing git
+    {ref}`Gitolite <install-gitolite>` is a tool installed on a central server for managing git
     repositories and controlling access to them, all via the command line. The
     central server becomes a git server.
 

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -2053,6 +2053,14 @@ SSH
 Secure Shell
     *Work in Progress*
 
+SSH-key
+Secure Shell Key
+    A cryptographic encryption key pair for {term}`SSH`, usually used and created with {term}`OpenSSH`.
+    It's split in two parts: a _public_ and a _private_ key files.
+    The private key is secret and belogs to the owning user, and it's used to prove posession of that secret.
+    The public key is not secret and is used to securely identify only the private key holder.
+    That way, entering a public key on a server for {term}`SSH` access, only the private key holder can log in.
+
 SSI
 Server-Side Includes
     *Work in Progress*


### PR DESCRIPTION
rewrite gitolite setup docs to fix #292 

on a side-note, i don't think this guide fits into the `how-to/backup` subdirectory, but no other existing one fits well. maybe `storage`? it's an development tool, maybe introduce `devtool`?

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.