### PR TITLE
Change indentation in kea config example

### DIFF
--- a/how-to/networking/install-isc-kea.md
+++ b/how-to/networking/install-isc-kea.md
@@ -48,46 +48,41 @@ pre-configured IP address pool. This can be done with settings as follows:
 
 ```json
 {
-  "Dhcp4": {
-	"interfaces-config": {
-  	"interfaces": [ "eth4" ]
-	},
-	"control-socket": {
-    	"socket-type": "unix",
-    	"socket-name": "/run/kea/kea4-ctrl-socket"
-	},
-	"lease-database": {
-    	"type": "memfile",
-    	"lfc-interval": 3600
-	},
-	"valid-lifetime": 600,
-	"max-valid-lifetime": 7200,
-	"subnet4": [
-  	{
-    	"id": 1,
-    	"subnet": "192.168.1.0/24",
-    	"pools": [
-      	{
-        	"pool": "192.168.1.150 - 192.168.1.200"
-      	}
-    	],
-    	"option-data": [
-      	{
-        	"name": "routers",
-        	"data": "192.168.1.254"
-      	},
-      	{
-        	"name": "domain-name-servers",
-        	"data": "192.168.1.1, 192.168.1.2"
-      	},
-      	{
-        	"name": "domain-name",
-        	"data": "mydomain.example"
-      	}
-    	]
-  	}
-	]
-  }
+    "Dhcp4": {
+        "interfaces-config": {
+            "interfaces": ["eth4"]
+        },
+        "control-socket": {
+            "socket-type": "unix",
+            "socket-name": "/run/kea/kea4-ctrl-socket"
+        },
+        "lease-database": {
+            "type": "memfile",
+            "lfc-interval": 3600
+        },
+        "valid-lifetime": 600,
+        "max-valid-lifetime": 7200,
+        "subnet4": [{
+            "id": 1,
+            "subnet": "192.168.1.0/24",
+            "pools": [{
+                "pool": "192.168.1.150 - 192.168.1.200"
+            }],
+            "option-data": [{
+                    "name": "routers",
+                    "data": "192.168.1.254"
+                },
+                {
+                    "name": "domain-name-servers",
+                    "data": "192.168.1.1, 192.168.1.2"
+                },
+                {
+                    "name": "domain-name",
+                    "data": "mydomain.example"
+                }
+            ]
+        }]
+    }
 }
 ```
 


### PR DESCRIPTION
### Description

This seeks to improve how the example kea dhcp4 config is rendered. This both changes leading tabs to spaces and creates indentation that was missing.

The result is that when rendered on the site, the configurations indentation follows the logical structure of the JSON.

---

### Commit Message for Squash Merge

We typically squash commits when merging. You can specify the commit message that should be used in this case if you wish.
Provide the desired commit message below:

> Change indentation in kea config example
> 
> This seeks to improve how the example kea dhcp4 config is rendered. This both changes leading tabs to spaces and creates indentation that was missing.
> 
> The result is that when rendered on the site, the configurations indentation follows the logical structure of the JSON.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
