### PR TITLE
Chrony client: Document how to avoid non-NTS time sources provided by DHCP

### DIFF
--- a/how-to/networking/chrony-client.md
+++ b/how-to/networking/chrony-client.md
@@ -47,9 +47,14 @@ pool 1.ntp.ubuntu.com iburst maxsources 1 nts prefer
 For **validation of NTS enablement**, one can list the time sources in use by executing the `chronyc -N sources` command, to find the timeserver in use, as indicated by the `^*` symbol in the first column. Then check the `authdata` of that connection using `sudo chronyc -N authdata`. If the client was able to successfully establish a NTS connection, it will show the `Mode: NTS` field and non-zero values for `KeyID`, `Type` and `KLen`:
 
 ```text
+$ sudo chronyc -N authdata
 Name/IP address             Mode KeyID Type KLen Last Atmp  NAK Cook CLen
 =========================================================================
-<server-fqdn-or-ip>          NTS     1   15  256  48h    0    0    8  100
+1.ntp.ubuntu.com             NTS     6   30  128  14d    0    0    8   64
+2.ntp.ubuntu.com             NTS     6   30  128  14d    0    0    8   64
+3.ntp.ubuntu.com             NTS     1   30  128  27d    0    0    8   64
+4.ntp.ubuntu.com             NTS     2   30  128  20d    0    0    5   64
+ntp-bootstrap.ubuntu.com     NTS     3   30  128   7d    0    0    8   64
 ```
 
 ### NTS related constraints

--- a/how-to/networking/chrony-client.md
+++ b/how-to/networking/chrony-client.md
@@ -109,6 +109,14 @@ After adding or removing sources, they can be reloaded using `sudo chrony reload
 
 Of the pool, `2.ubuntu.pool.ntp.org` and `ntp.ubuntu.com` also support IPv6, if needed. If you need to force IPv6, there is also `ipv6.ntp.ubuntu.com` which is not configured by default.
 
+### Time sources provided by DHCP (option 42)
+
+Chrony consumes time sources provided by DHCP (option 42). Those could be traditional, non-authenticated NTP sources. Should one want to avoid this behavior, overruling the choices made by a local DHCP administrator, it can be disabled in `/etc/chrony/chrony.conf`. To do that one would comment out the corresponding setting:
+```
+# Use time sources from DHCP.
+# sourcedir /run/chrony-dhcp
+```
+
 ### Chrony time-daemon
 
 `chronyd` itself is a normal service, so you can check its status in more detail using:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Description

Describe how people can overrule the decisions of local DHCP admins, to avoid any NTP/non-NTS time sources provided via DHCP (option 42)

---

### Related Issue

https://bugs.launchpad.net/ubuntu/+source/chrony/+bug/2115565

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Commit Message for Squash Merge

We typically squash commits when merging. You can specify the commit message that should be used in this case if you wish.
Provide the desired commit message below:

[(optional) category] Brief description of changes made, and why

---

### Checklist

- [ ] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [ ] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [ ] My pull request is linked to an existing issue (if applicable).
- [ ] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
