### PR TITLE
Use latest LTS for manpages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -112,8 +112,8 @@ if 'custom_rst_epilog' in locals():
 if 'custom_manpages_url' in locals():
     manpages_url = custom_manpages_url
 else:
-    manpages_distribution = subprocess.check_output("distro-info --stable", 
-                                                text=True, shell=True).strip()
+    manpages_distribution = subprocess.check_output(["distro-info", "--lts"],
+                                                text=True, shell=False).strip()
     manpages_url = ("https://manpages.ubuntu.com/manpages/"
                     f"{manpages_distribution}/en/"
                     "man{section}/{page}.{section}.html")


### PR DESCRIPTION

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Description

This MP switches the `{manpage}` magic link to use the latest LTS, instead of the latest stable release of Ubuntu. This is needed because the documentation is LTS focused.

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
