### PR TITLE
sssd/ad: Replace systemd-resolve with resolvectl

### DIFF
--- a/how-to/sssd/with-active-directory.md
+++ b/how-to/sssd/with-active-directory.md
@@ -15,7 +15,7 @@ This guide does not explain Active Directory, how it works, how to set one up, o
 
 - The domain controller is:
   - Acting as an authoritative {term}`DNS` server for the domain.
-  - The primary DNS resolver (check with `systemd-resolve --status`).
+  - The primary DNS resolver (check with `resolvectl status`).
 - System time is correct and in sync, maintained via a service like `chrony` or `ntp`.
 - The domain used in this example is `ad1.example.com` .
 


### PR DESCRIPTION
Just a nit I noticed while working through this document; `systemd-resolve` doesn't exist in jammy, although it has a [manpage symlink](https://manpages.ubuntu.com/manpages/jammy/en/man1/systemd-resolve.1.html).

---

### Commit Message for Squash Merge

```
sssd/ad: Replace systemd-resolve with resolvectl
```

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [ ] ~~My pull request is linked to an existing issue (if applicable).~~
- [x] I have tested my changes, and they work as expected.