### PR TITLE
Add missing redirect

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -448,6 +448,7 @@ explanation/storage/iscsi-initiator-or-client/ how-to/storage/iscsi-initiator-or
 about-apt-upgrade-and-phased-updates explanation/software/about-apt-upgrade-and-phased-updates/
 
 third-party-repository-usage explanation/software/third-party-repository-usage/
+third-party-apt-repositories explanation/software/third-party-repository-usage/
 
 changing-package-files explanation/software/changing-package-files/
 


### PR DESCRIPTION
### Description

This redirect was missing from the original Discourse redirect table, and was not included in the post-migration-to-RTD redirects list.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

