### PR TITLE
Fix netboot documentation for amd64 via UEFI

### DIFF
--- a/how-to/installation/how-to-netboot-the-server-installer-on-amd64.md
+++ b/how-to/installation/how-to-netboot-the-server-installer-on-amd64.md
@@ -143,7 +143,7 @@ ln -s /usr/share/cd-boot-images-amd64 /srv/tftp/boot-amd64
 
    menuentry 'Ubuntu 24.04' {
       gfxmode $linux_gfx_mode
-      linux /vmlinuz $vt_handoff quiet splash
+      linux /vmlinuz $vt_handoff quiet splash root=/dev/ram0 ramdisk_size=1500000 cloud-config-url=/dev/null ip=dhcp url=http://cdimage.ubuntu.com/ubuntu-server/noble/daily-live/current/noble-live-server-amd64.iso
       initrd /initrd
    }
    EOF


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Description

The example `grub.cfg` in the UEFI section of "netboot on AMD64" is missing the kernel parameters to setup an appropriate RAM disk and load the installer ISO image.

---

### Related Issue

* Fixes #342 


---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Commit Message for Squash Merge

how-to:netboot-amd64: Add mandatory ip= & url= parameters                       
                                                                                   
Besides this also adding root=, ramdisk_size= & cloud-config-url= optimizations.
And commenting out an internal note & adding `sudo` where needed.
                                                                                
Fixes: https://github.com/canonical/ubuntu-server-documentation/issues/342  
       
---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Tested via LXD, using this network configuration for PXE:                       
```                                                                             
name: lxdpxe0                                                                   
description: ""                                                                 
type: bridge                                                                    
managed: true                                                                   
status: Created                                                                 
config:                                                                         
  ipv4.address: 10.176.161.1/24                                                 
  ipv4.nat: "true"                                                              
  ipv6.address: fd42:219e:cafd:eab5::1/64                                       
  ipv6.nat: "true"                                                              
  raw.dnsmasq: |-                                                               
    dhcp-boot=pxelinux.0                                                        
    dhcp-match=set:efi-x86_64,option:client-arch,7                              
    dhcp-boot=tag:efi-x86_64,bootx64.efi                                        
    enable-tftp                                                                 
    tftp-root=/var/snap/lxd/common/lxd/tftp                                     
used_by:                                                                        
- /1.0/profiles/dual-nic                                                        
- /1.0/instances/eager-seagull                                                  
locations:                                                                      
- none                                                                          
project: default                                                                
```                                                                             
                                                                                
Then launched VM via, hitting "ESC" during the UEFI stage,                      
selecting "Boot Manager" -> "UEFI PXEv4 (MAC:...)" on the corresponding interface:
```                                                                             
lxc launch --vm ubuntu-daily:questing -c limits.memory=8GiB -p dual-nic --console=vga
```

---

Thank you for contributing to the Ubuntu Server documentation!
