### PR TITLE
Update a link from the wiki to project docs

### DIFF
--- a/how-to/software/upgrade-your-release.md
+++ b/how-to/software/upgrade-your-release.md
@@ -127,4 +127,4 @@ Continue [yN]
 
 ## Further reading
 
-- For a complete list of releases and current support status see the [Ubuntu Wiki Releases](https://wiki.ubuntu.com/Releases) page.
+- For a complete list of releases and current support status, see the [List of releases](https://documentation.ubuntu.com/project/release-team/list-of-releases/) page.


### PR DESCRIPTION

I've found a link pointing to the Ubuntu wiki, which auto-redirects to the Ubuntu Project Docs. I'm updating the link to skip the wiki.
