### PR TITLE
Adjust copybutton config

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -255,6 +255,20 @@ custom_html_js_files = [
     'js/bundle.js',
 ]
 
+# Configure copybutton extension
+# This option excludes line numbers and prompts from being selected when
+# users copy commands using the copybutton
+# https://sphinx-copybutton.readthedocs.io/en/latest/use.html#automatic-exclusion-of-prompts-from-the-copies
+
+# This regex was implemented by rkratky for the Ubuntu Project docs. It uses
+# '|' because of a bug in copybutton extension:
+#     https://github.com/executablebooks/sphinx-copybutton/issues/96
+# Replace with   r"(\S+@\S+)?[\$\#] "  when the bug is fixed.
+copybutton_prompt_text = r"\S+@\S+[\$\#] |[\$\#] "
+copybutton_prompt_is_regexp = True
+copybutton_line_continuation_character = "\\"
+
+
 ## The following settings override the default configuration.
 
 # Specify a reST string that is included at the end of each file.


### PR DESCRIPTION
### Description

The Sphinx copybutton can be configured to strip prompts so that when a user copies a command block it only copies the command. This PR implements that behaviour so we can now include `$` and `#` in commands: now when a user copies a code block via the button the prompt and any lines without a prompt will be excluded.

(thanks to rkratky for the regex)

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

I tested this locally using the explanation > performance > PGO page, which contains code blocks including prompts.