### PR TITLE
Bacula docs update

### DIFF
--- a/how-to/backups/install-bacula.md
+++ b/how-to/backups/install-bacula.md
@@ -421,7 +421,7 @@ We made many changes to a few configuration files, so let's restart all the rela
 sudo systemctl restart bacula-dir.service bacula-fd.service bacula-sd.service
 ```
 
-## Our first backup and restore
+## Running a backup job
 We now have everything in place to run our first backup job.
 
 On the Bacula Director system, run the `bconsole` command as root to enter the Bacula Console:
@@ -532,6 +532,8 @@ If we inspect the backup target location on the Storage server (which in this de
 ```
 -rw-r----- 1 bacula tape 345K Oct 20 20:21 /storage/backups/Vol-0001
 ```
+
+## Restoring a backup
 
 So what is it that was backed up? This job used the `Home Set`, so we expect to see files from the `/home` directory. To see what are the contents of that backup job, we can use the `restore` command (the `RestoreFiles` job should never be executed directly). Below is the output of an interactive `restore` session where we selected the option "Select the most recent backup for a client":
 ```text


### PR DESCRIPTION
### Description
I think this looks good enough now. It's certainly an order of magnitude better than what we have in the docs right now, in my (biased) opinion.

Bacula major documentation update for the Ubuntu Server Guide.

---

### Related Issue
Part of https://warthogs.atlassian.net/browse/SD-1075

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)
Might do these in a follow-up PR:
- ~~I want to go over it one more time, from top to bottom, and follow the instructions~~
- ~~I want to try it with Noble's version of bacula as well: the docs as written apply to Questing, and soon-to-be-released Resolute~~
- if there is time, I would like to standardize on better Job names
- if there is time, I would like to add an image showing the components and their relations
- I'll likely squash all commits at some point
- I was wondering if it wouldn't be best to move all "tips" with URLs to the Reference section at the end
