### PR TITLE
Add flowchart for home network setup in documentation

### DIFF
--- a/how-to/wireguard-vpn/peer-to-site.md
+++ b/how-to/wireguard-vpn/peer-to-site.md
@@ -10,20 +10,23 @@ Where to place the remote WireGuard endpoint in the network will vary a lot depe
 
 Here we will cover a simpler case more resembling what a home network could be like:
 
-```
-               public internet
-     
-                xxxxxx      ppp0 ┌────────┐
- ┌────┐         xx   xxxx      ──┤ router │
- │    ├─ppp0  xxx      xx        └───┬────┘
- │    │       xx        x            │         home 10.10.10.0/24
- │    │        xxx    xxx            └───┬─────────┬─────────┐
- └────┘          xxxxx                   │         │         │
-                                       ┌─┴─┐     ┌─┴─┐     ┌─┴─┐
-                                       │   │     │   │     │   │
-                                       │pi4│     │NAS│     │...│
-                                       │   │     │   │     │   │
-                                       └───┘     └───┘     └───┘
+```mermaid
+
+flowchart LR
+ subgraph home["home — 10.10.10.0/24"]
+        pi4["pi4"]
+        nas["NAS"]
+        Y["Y"]
+        dots["..."]
+  end
+    router["router"] --- pi4 & nas & Y & dots
+    host["host"] -- |ppp0| --> internet(("public internet"))
+    internet -- |ppp0| --> router
+    style router fill:#FFE0B2
+    style host fill:#E1BEE7
+    style internet fill:#C8E6C9
+    style home fill:#FFF9C4
+
 ```
 
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Description

Added a flowchart diagram to illustrate a simple home network setup for WireGuard VPN. I replaced the existing Markdown ASCII diagram by a Mermaid one to make maintenance easier. Peer-to-site.


---

### Related Issue

If this pull request addresses an existing issue, please link to it below. Use the `Fixes #<issue-number>` syntax to
[close the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) automatically when the pull request is merged.

Example:

- Fixes: #118

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Commit Message for Squash Merge

We typically squash commits when merging. You can specify the commit message that should be used in this case if you wish.
Provide the desired commit message below:

[(optional) category] Brief description of changes made, and why

---

### Checklist

- [x ] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [ x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x ] My pull request is linked to an existing issue (if applicable).
- [ x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

I have added an extra internal device the user may have at home, I called it Y. This was to reinforce the impression that users may have multiple internal devices beyond those mentioned in the guide.

---

Thank you for contributing to the Ubuntu Server documentation!
