### PR TITLE
user-management: fix regex for filtering regular users from /etc/passwd

### DIFF
--- a/how-to/security/user-management.md
+++ b/how-to/security/user-management.md
@@ -109,9 +109,9 @@ sys
 ```
 If you want to only show regular users, that is, users with an UID greater than 1000, we can use a regular expression for this filtering:
 ```
-cat /etc/passwd | cut -d : -f 1,3 | grep -E ':[0-9]{4}+'
+cat /etc/passwd | cut -d : -f 1,3 | grep -E ':[0-9]{4,}'
 ```
-The regular expression `:[0-9]{4}+` means all digits, repeated 4 times or more. The output will be similar to this:
+The regular expression `:[0-9]{4,}` means all digits, repeated 4 times or more. The output will be similar to this:
 ```
 nobody:65534
 ubuntu:1000


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Description

The documentation uses an invalid regular expression to filter for UID of 1000 and higher from `/etc/passwd` and used the same regular expression in the detailed explanation. The regular expression using two successive quantifier. This is an invalid syntax, does not achieve the intended result and is non-POSIX compliant.

---

### Related Issue

- Fixes: #404

---

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

---

### Commit Message for Squash Merge

We typically squash commits when merging. You can specify the commit message that should be used in this case if you wish.
Provide the desired commit message below:

[(optional) category] Brief description of changes made, and why

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] I have signed the [Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
