### PR TITLE
Update ftp.md

### DIFF
--- a/how-to/networking/ftp.md
+++ b/how-to/networking/ftp.md
@@ -72,6 +72,10 @@ You can also limit a specific list of users to just their home directories:
     chroot_list_enable=YES
     chroot_list_file=/etc/vsftpd.chroot_list
 
+```{warning}
+If chroot_local_user is set to YES (setting all users to be limited a to just their home directories), /etc/vsftpd.chroot_list becomes a list of users which are NOT limited a to just their home directories
+```
+
 After uncommenting the above options, create a `/etc/vsftpd.chroot_list` containing a list of users one per line. Then restart vsftpd:
 
     sudo systemctl restart vsftpd.service


### PR DESCRIPTION
Added warning that setting chroot_local_user inverts the meaning of chroot_list_file

### Description

The current documentation does not make it clear that chroot_list_file becomes a list of users NOT to be chrooted if chroot_local_user=YES. If following the current documentation is is likely a user would use both options and achieve the opposite of what they intended
