### PR TITLE
[GitHub Copilot test] Optimize link checking

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -1,11 +1,11 @@
 name: Automatic doc checks
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    paths:
-      - 'docs/**'   # Only run on changes to the docs directory
+#on:
+#  push:
+#    branches: [ main ]
+#  pull_request:
+#    paths:
+#      - 'docs/**'   # Only run on changes to the docs directory
 
   workflow_dispatch:
     # Manual trigger


### PR DESCRIPTION
### Description

Another test of GitHub Copilot's capabilities. This time, I set it the task of benchmarking the linkcheck automated test and find some optimizations. The linkchecker has been a perennial problem in that it's extremely slow and hardly ideal for being run on every PR.

**Performance Improvement in round 1:**
* Before: 9m 57.7s
* After: 2m 48.1s
* Improvement: 7m 9.6s faster (71.8% reduction in runtime)

**Changes Made:**
* Added rate-limited domains to ignore list:
  * http://www.gnu.org/software/* (was causing 16 rate-limit delays)
  * https://github.com/.*/blob/.* (was causing 5 rate-limit delays)
* Faster failure on slow/broken links:
  * Reduced wait time per failing URL from 30s to 15s
  * Reduced retries: 3 → 2

**Performance improvement in round 2:**
* Adding 20 workers on top saved another 1m 17.4s (46% faster than round 1)
* Overall (total) improvement from baseline: 8m 27s saved (from ~10min to ~1.5min)
* No rate-limiting issues triggered with 20 workers (still 0 rate-limited links)

GHC also suggested adding broken links to the ignore list (not done for obvious reasons) and cleaning up redirects. Cleaning up redirects will be done separately - I see potential for automation via a python script we could run as a periodic (weekly or monthly) github action.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Confirmation that the linkcheck now only takes 1.5 minutes to run:

<img width="1811" height="551" alt="image" src="https://github.com/user-attachments/assets/61dfd761-7b4f-4bbf-8f5e-f71f8d366e07" />


---

Thank you for contributing to the Ubuntu Server documentation!
