### PR TITLE
force ogp to use default metadescription

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,8 @@ ogp_site_name = project
 # Preview image URL
 ogp_image = "https://assets.ubuntu.com/v1/cc828679-docs_illustration.svg"
 
+# Tell the Open Graph extension to use the standard HTML meta description
+ogp_enable_meta_description = True
 
 # Product favicon; shown in bookmarks, browser tabs, etc.
 html_favicon = ".sphinx/_static/favicon.png"


### PR DESCRIPTION
### Description

After applying metadata descriptions to every page, it's been noticed that OGP isn't picking up the meta descriptions and is still creating its own based on the first 140ish characters of each page's body text.

This PR adds a line to the config to force OGP to use the `html_meta` description set on every page.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
