### PR TITLE
Fix link that points to ssh keys

### DIFF
--- a/docs/how-to/security/openssh-server.md
+++ b/docs/how-to/security/openssh-server.md
@@ -71,6 +71,8 @@ sudo systemctl restart ssh.service
 Many other configuration directives for `sshd` are available to change the server application's behavior to fit your needs. Be advised, however, if your only method of access to a server is SSH, and you make a mistake when configuring `sshd` via the `/etc/ssh/sshd_config` file, you may find you are locked out of the server upon restarting it. Additionally, if an incorrect configuration directive is supplied, the `sshd` server may refuse to start, so be particularly careful when editing this file on a remote server.
 ```
 
+(openssh-server-ssh-keys)=
+
 ## SSH keys
 
 SSH allows authentication between two hosts without the need of a password, using cryptographic keys instead.

--- a/docs/how-to/virtualisation/virtual-machine-manager.md
+++ b/docs/how-to/virtualisation/virtual-machine-manager.md
@@ -30,7 +30,7 @@ virt-manager -c qemu+ssh://virtnode1.mydomain.com/system
 ```
 
 ```{note}
-The above example assumes that SSH connectivity between the management system and the target system has already been configured, and uses **SSH keys** for authentication. SSH keys are needed because libvirt sends the password prompt to another process. See our guide on OpenSSH for details on {ref}`how to set up SSH keys <smart-card-authentication-with-ssh>`.
+The above example assumes that SSH connectivity between the management system and the target system has already been configured, and uses **SSH keys** for authentication. SSH keys are needed because libvirt sends the password prompt to another process. See our guide on OpenSSH for details on {ref}`how to set up SSH keys <openssh-server-ssh-keys>`.
 ```
 
 ## Use virt-manager to manage guests


### PR DESCRIPTION
### Description

Point to the correct existing page inside the documentation that shows how to setup ssh keys.

- Fixes: #434

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
