### PR TITLE
Fix pdf

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,8 +30,8 @@ sphinx:
   fail_on_warning: false
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-#formats:
-#   - pdf
+formats:
+   - pdf
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
### Description

PDF build was disabled while we tested the proxy setup. Since this is now being postponed, I'm re-enabling the PDF build so that the PDF is still available.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
