### PR TITLE
Add git.launchpad to list of ignored domains

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -241,6 +241,7 @@ linkcheck_ignore = [
     "https://sourceforge.net/*",
     "https://ubuntu.com/blog/*",
     "https://help.ubuntu.com/*",
+    "https://git.launchpad.net/*",
     # Rate-limited domains that cause delays
     r"http://www\.gnu\.org/software/.*",
     r"https://github\.com/.*/blob/.*",


### PR DESCRIPTION
### Description

The git.launchpad.net domain now triggers failures on the spellchecker. The failing URLs are valid, so adding this domain to the ignore list.
 

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
