### PR TITLE
hyper-v: remove statement about most recent versions being available

### DIFF
--- a/docs/how-to/virtualisation/ubuntu-on-hyper-v.md
+++ b/docs/how-to/virtualisation/ubuntu-on-hyper-v.md
@@ -80,7 +80,7 @@ The recommended method is to use the curated Ubuntu image from the Hyper-V Quick
 
 1. On the 'Actions' pane select 'Quick Create' and the Quick Create tool will open.
 
-1. Select a version of Ubuntu from the versions on the list. A build of the [most recent LTS](https://wiki.ubuntu.com/LTS) version of Ubuntu and the [most recent interim release](https://wiki.ubuntu.com/Releases) are provided.
+1. Select a version of Ubuntu from the versions on the list.
 
    * The **LTS version** is recommended if you are developing for Ubuntu Server or an enterprise environment.
    * The **interim release** is recommended if you would like to use the latest versions of software in Ubuntu.


### PR DESCRIPTION
### Description
This is a workaround for issue #133.

I basically removed the statement that said the most recent images would be available. The whole text still reads fine without it.

Internally, I pinged the CPC team a second time, for them so ping a contact at Microsoft about this, but there is no expectation of when, or if, Microsoft will update their tool.

I suggest for affected users to also poke Microsoft in their forums, if this is relevant to them.

### Contributor License Agreement (CLA)

By contributing to this project, you agree to the terms of
the [Canonical Contributor License Agreement (CLA)](https://ubuntu.com/legal/contributors).  
If you have not already signed the CLA, [please do so here](https://ubuntu.com/legal/contributors).

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
