### PR TITLE
Update manpage stable distribution to 'resolute'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -270,7 +270,7 @@ linkcheck_workers = 20
 # NOTE: If set, adding "{manpage}" to an .md file adds a link to the
 # corresponding man section at the bottom of the page.
 
-stable_distro = "plucky"
+stable_distro = "resolute"
 
 manpages_url = (
     "https://manpages.ubuntu.com/manpages/"


### PR DESCRIPTION
### Description

Update stable distribution so that manpage roles point to resolute instead of plucky

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
