### PR TITLE
Deprecate isc-dhcp-server for Ubuntu 26.04 and mention other DHCP servers

### DIFF
--- a/docs/explanation/intro-to/networking.md
+++ b/docs/explanation/intro-to/networking.md
@@ -27,11 +27,9 @@ If you are a server administrator, check out our explanatory guide on {ref}`conf
 
 The Dynamic Host Configuration Protocol (DHCP) enables host computers to be automatically assigned settings from a server. To learn more about DHCP and how configuration works, we have {ref}`an explanatory guide <about-dhcp>`.
 
-There are two DHCP servers available on Ubuntu.  
- * **`isc-kea`** (available from 23.04 onward)
- * **`isc-dhcp-server`** (no longer supported by vendor)
+The recommended DHCP server for Ubuntu is **`isc-kea`** (available from 23.04 onward). There are also other DHCP servers available, including `dnsmasq` which provides combined DHCP and DNS functionality.
 
-Learn how to {ref}`install isc-kea <install-isc-kea>` or {ref}`install and configure isc-dhcp-server <install-isc-dhcp-server>`.
+Learn how to {ref}`install isc-kea <install-isc-kea>` or explore other {ref}`DHCP server options <about-dhcp>`.
 
 ### Time synchronization
 

--- a/docs/explanation/networking/about-dhcp.md
+++ b/docs/explanation/networking/about-dhcp.md
@@ -47,17 +47,21 @@ The last two methods can be considered "automatic" because in each case the DHCP
 
 ## Available servers
 
-Ubuntu makes two DHCP servers available:
-
-- `isc-dhcp-server`:
-  This server installs `dhcpd`, the dynamic host configuration protocol daemon. Although Ubuntu still supports `isc-dhcp-server`, this software is [no longer supported by its vendor](https://www.isc.org/blogs/isc-dhcp-eol/).
-
-  Find out {ref}`how to install and configure isc-dhcp-server <install-isc-dhcp-server>`.
+Ubuntu provides several DHCP servers. The following are the most common:
 
 - `isc-kea`:
-  [Kea](https://www.isc.org/kea/) was created by ISC to replace `isc-dhcp-server` -- It is supported in Ubuntu releases from 23.04 onward.
+  [Kea](https://www.isc.org/kea/) is the recommended DHCP server for new deployments. It was created by ISC to replace `isc-dhcp-server` and is supported in Ubuntu releases from 23.04 onward.
 
   Find out {ref}`how to install and configure isc-kea <install-isc-kea>`.
+
+- `dnsmasq`:
+  [dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) provides combined DNS and DHCP functionality. It is lightweight and suitable for small networks and development environments.
+
+```{note}
+The `isc-dhcp-server` package is deprecated and unsupported since Ubuntu 24.04 LTS. Please use `isc-kea` or `dnsmasq` instead.
+```
+
+Legacy documentation for `isc-dhcp-server` is still available for existing deployments. You can find {ref}`information on how to configure it <install-isc-dhcp-server>` if needed.
 
 
 ## References

--- a/docs/how-to/networking/install-isc-dhcp-server.md
+++ b/docs/how-to/networking/install-isc-dhcp-server.md
@@ -7,8 +7,8 @@ myst:
 (install-isc-dhcp-server)=
 # How to install and configure isc-dhcp-server
 
-```{note}
-Although Ubuntu still supports `isc-dhcp-server`, this software is [no longer supported by its vendor](https://www.isc.org/blogs/isc-dhcp-eol/). It has been replaced by [Kea](https://www.isc.org/kea/).
+```{warning}
+The `isc-dhcp-server` package is deprecated and unuspported since Ubuntu 24.04 LTS. It is no longer supported by its vendor. Please use [Kea](https://www.isc.org/kea/) or [dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) instead.
 ```
 
 In this guide we show how to install and configure `isc-dhcp-server`, which installs the dynamic host configuration protocol daemon, {term}`DHCPD`. For `isc-kea` instructions, {ref}`refer to this guide instead <install-isc-kea>`.


### PR DESCRIPTION
This PR addresses issue #471 by:

- Removing isc-dhcp-server from the recommended DHCP servers list
- Prioritizing isc-kea as the recommended DHCP server
- Adding documentation for dnsmasq as an alternative lightweight DHCP/DNS server
- Adding clear deprecation notices indicating that isc-dhcp-server is unsupported since 24.04

Changes made to:
- `docs/explanation/intro-to/networking.md` - Updated DHCP section
- `docs/explanation/networking/about-dhcp.md` - Restructured server options
- `docs/how-to/networking/install-isc-dhcp-server.md` - Added deprecation warning

Fixes: #471