### PR TITLE
Apache2 installation page improvements

### DIFF
--- a/docs/how-to/web-services/install-apache2.md
+++ b/docs/how-to/web-services/install-apache2.md
@@ -7,7 +7,7 @@ myst:
 (install-apache2)=
 # How to install Apache2
 
-[The Apache HTTP Server](https://httpd.apache.org/) ("httpd") is the most commonly used web server on Linux systems, and is often used as part of the LAMP configuration. In this guide, we will show you how to install and configure Apache2, which is the current release of "httpd".
+[The Apache HTTP Server](https://httpd.apache.org/) ("httpd") is a widely used web server on Linux systems, and is often used as part of the LAMP configuration (Linux + Apache + MySQL + PHP/Perl/Python). In this guide, we will show you how to install and configure Apache2, which is the current release of "httpd".
 
 ## Install `apache2`
 


### PR DESCRIPTION
- Update the page meta description: there are no specifics on LAMP here, so let's drop it.
- Do not say apache2 is the MOST used web server (since we do not show data to back it up)
- Expand LAMP