### PR TITLE
Squid explanation page improvements

### DIFF
--- a/docs/explanation/web-services/about-squid-proxy-servers.md
+++ b/docs/explanation/web-services/about-squid-proxy-servers.md
@@ -7,21 +7,25 @@ myst:
 (about-squid-proxy-servers)=
 # About Squid proxy servers
 
-[Squid](http://www.squid-cache.org/) is a proxy caching server which provides proxy and cache services for Hyper Text Transport Protocol (HTTP), File Transfer Protocol (FTP), and other popular network protocols. 
-
-It acts as an intermediary between web servers and clients. When a client sends a request for content, Squid fetches the content from the web server and creates a local copy. Then, if a request is made again, it shows the local, cached copy instead of making another request to the web server. In this way, performance is improved and network bandwidth is optimized. It can also filter web traffic, helping to improve security.
-
-## Features
+[Squid](http://www.squid-cache.org/) is a proxy caching server. It provides proxy and cache services for Hyper Text Transport Protocol (HTTP), File Transfer Protocol (FTP), and other popular network protocols. It acts as an intermediary between web servers and clients, storing content from the web and then providing a local copy for fast access, which improves network performance. It can also filter web traffic, helping to improve security.
 
 The Squid proxy cache server scales from the branch office to enterprise level networks. It provides extensive, granular access controls, and monitoring of critical parameters via the Simple Network Management Protocol (SNMP).
 
-When selecting a computer system for use as a dedicated Squid caching proxy server, it is helpful to configure it with a large amount of physical memory as Squid maintains an in-memory cache for increased performance.
-
 ## Caching
 
-Squid can implement caching and proxying of Secure Sockets Layer (SSL) requests and caching of Domain Name Server ({term}`DNS`) lookups, and perform transparent caching. Squid also supports a wide variety of caching protocols, such as Internet Cache Protocol (ICP), the Hyper Text Caching Protocol (HTCP), the Cache Array Routing Protocol (CARP), and the Web Cache Coordination Protocol (WCCP).
+Squid improves network performance by storing frequently accessed web content locally. When a client requests content, Squid retrieves it from the origin server and caches a copy. Subsequent requests for the same content are served from the cache, eliminating redundant network traffic and reducing latency.
+
+Besides HTTP and FTP, Squid can implement caching and proxying of Secure Sockets Layer (SSL) requests and caching of Domain Name Server ({term}`DNS`) lookups, and perform transparent caching. Squid also supports a wide variety of caching protocols, such as Internet Cache Protocol (ICP), the Hyper Text Caching Protocol (HTCP), the Cache Array Routing Protocol (CARP), and the Web Cache Coordination Protocol (WCCP).
 
 Squid caching can be done in-RAM for fastest access, on disk for larger capacity, and may use a hierarchical directory structure for efficient file organization.
+
+## Filtering
+
+Squid provides access control and content filtering capabilities through Access Control Lists (ACLs). ACLs define rules that match specific traffic characteristics, which are then combined with allow/deny directives to control request handling. This enables administrators to implement security policies, restrict access to inappropriate content, and manage bandwidth consumption.
+
+Filters can be applied based on source criteria (client IP addresses, network ranges, authenticated usernames), destination criteria (domain names, URL patterns, destination IPs, port numbers), content characteristics (MIME types, file extensions, HTTP methods), temporal restrictions (time of day, day of week, date ranges), protocol attributes (HTTP headers, request methods, SSL certificate properties), and content keywords (regular expressions matching URLs or request content).
+
+## Installing and configuring
 
 If you would like to know how to install and configure your own Squid server, refer to {ref}`our installation guide <install-a-squid-server>`.
 


### PR DESCRIPTION
### Description

The page had a couple random sentences with unnecessary detail among the text, lacked structure for the caching explanation and had no filtering explanation.

The content is not wrong, but some was missing and now there is a clear separation of concerns between sections.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [n/a] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

Thank you for contributing to the Ubuntu Server documentation!

you welcome