### PR TITLE
Add syslinux wiki to ignored domains

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -243,6 +243,7 @@ linkcheck_ignore = [
     "https://help.ubuntu.com/*",
     "https://git.launchpad.net/*",
     "https://linuxcontainers.org/*",
+    "https://wiki.syslinux.org/*",
     # Rate-limited domains that cause delays
     r"http://www\.gnu\.org/software/.*",
     r"https://github\.com/.*/blob/.*",


### PR DESCRIPTION
### Description

The link is valid and works, but keeps triggering a failure in the linkchecker. Adding to the ignore list.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
