### PR TITLE
Update docker.io default storage driver string

### DIFF
--- a/docs/how-to/containers/docker-for-system-admins.md
+++ b/docs/how-to/containers/docker-for-system-admins.md
@@ -179,7 +179,7 @@ Otherwise, if you configure the Docker daemon to use a storage driver different 
   ```bash
   $ docker info | grep "Storage Driver"
 
-  Storage Driver: overlay2
+  Storage Driver: overlayfs
   ```
 
 - Ensure the required Filesystem is available. We will be using the ZFS Filesystem.


### PR DESCRIPTION
Minor change on the name of the default docker storage driver as presented in resolute to avoid confusion.