### PR TITLE
Fix 481 configuring networks

### DIFF
--- a/docs/explanation/networking/configuring-networks.md
+++ b/docs/explanation/networking/configuring-networks.md
@@ -260,7 +260,7 @@ Name resolution (as it relates to IP networking) is the process of mapping {term
 
 <h3 id="heading--dns-client-configuration">DNS client configuration</h3>
 
-Traditionally, the file `/etc/resolv.conf` was a static configuration file that rarely needed to be changed, or it automatically changed via DHCP client hooks. `systemd-resolved` handles nameserver configuration, and it should be interacted with through the `resolvectl` command. Up to Ubuntu 20.04 LTS the `systemd-resolve` command could as well be used. Netplan configures `systemd-resolved` to generate a list of nameservers and domains to put in `/etc/resolv.conf`, which is a symlink:
+Traditionally, the file `/etc/resolv.conf` was a static configuration file that rarely needed to be changed, or it automatically changed via DHCP client hooks. `systemd-resolved` handles nameserver configuration, and it should be interacted with through the `resolvectl` command. Up to Ubuntu 20.04 LTS the `systemd-resolve` command could also be used. Netplan configures `systemd-resolved` to generate a list of nameservers and domains to put in `/etc/resolv.conf`, which is a symlink:
 
 ```
 /etc/resolv.conf -> /run/systemd/resolve/stub-resolv.conf


### PR DESCRIPTION
* Improve 'identify ethernet interfaces' section, by also mentioning `netplan status`
* Avoid recommending direct edits of /etc/resolv.conf, use resolvectl instead
* Fix typo
* Fix references

Fixes: https://github.com/canonical/ubuntu-server-documentation/issues/481