### PR TITLE
Explain how to re-enable the Ctrl+Alt+Del shortcut

### DIFF
--- a/docs/how-to/security/console-security.md
+++ b/docs/how-to/security/console-security.md
@@ -7,16 +7,15 @@ myst:
 (console-security)=
 # Console security
 
-
 It is difficult to defend against the damage that can be caused by someone with physical access to your environment, for example, due to theft of hard drives, power or service disruption, and so on. 
 
 Console security should be addressed as one component of your overall physical security strategy. A locked "screen door" may deter a casual criminal, or at the very least slow down a determined one, so it is still advisable to perform basic precautions with regard to console security.
 
 ## Disable Ctrl+Alt+Delete
 
-Anyone with physical access to the keyboard can use the <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Delete</kbd> key combination to reboot the server without having to log on. While someone could also simply unplug the power source, you should still prevent the use of this key combination on a production server. This forces an attacker to take more drastic measures to reboot the server, and will prevent accidental reboots at the same time.
+Anyone with physical access to the keyboard can use the {kbd}`Ctrl` + {kbd}`Alt` + {kbd}`Delete` key combination to reboot the server without having to log on. While someone could also simply unplug the power source, you should still prevent the use of this key combination on a production server. This forces an attacker to take more drastic measures to reboot the server, and will prevent accidental reboots at the same time.
 
-To disable the reboot action taken by pressing the <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Delete</kbd> key combination, run the following two commands:
+To disable the reboot action taken by pressing the {kbd}`Ctrl` + {kbd}`Alt` + {kbd}`Delete` key combination, run the following two commands:
 
 ```bash
 sudo systemctl mask ctrl-alt-del.target


### PR DESCRIPTION
### Description

Probably not strictly necessary, but it's helpful to have instructions on how to re-enable the shortcut if needed.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
