### PR TITLE
Fixes to the third party repository page

### DIFF
--- a/docs/explanation/software/third-party-repository-usage.md
+++ b/docs/explanation/software/third-party-repository-usage.md
@@ -89,23 +89,23 @@ wget -O /usr/share/keyrings/externalrepo-archive-keyring.pgp https://thirdpartyr
 
 To add a third party APT repository to your system, you will need to create a file under `/etc/apt/sources.list.d/` with information about the external archive. This file is usually named after the repository (in our example, `externalrepo`). There are two standards the file can follow:
 
-* A one-line entry, which is the most common. In this case, the extension of the file should be `.list`.
-* The `deb822` format, which is more descriptive but less common. In this case, the extension of the file should be `.sources`.
-
-An example of a one-line entry would be the following:
-
-```
-deb [signed-by=/usr/share/keyrings/externalrepo-archive-keyring.pgp] https://thirdpartyrepo.com/ubuntu/ jammy main
-```
+* The `deb822` format, which is more descriptive, and is the current standard for Ubuntu. In this case, the extension of the file should be `.sources`.
+* A one-line entry, which was most common in past Ubuntu releases. In this case, the extension of the file should be `.list`.
 
 An example of a `deb822` file for the same case would be the following:
 
 ```
 Types: deb
 URIs: https://thirdpartyrepo.com/ubuntu
-Suites: jammy
+Suites: resolute
 Components: main
 Signed-By: /usr/share/keyrings/externalrepo-archive-keyring.pgp
+```
+
+An example of a one-line entry would be the following:
+
+```
+deb [signed-by=/usr/share/keyrings/externalrepo-archive-keyring.pgp] https://thirdpartyrepo.com/ubuntu/ resolute main
 ```
 
 There are cases when the third party APT repository may be served using HTTPS, in which case you will also need to install the `apt-transport-https` package.
@@ -134,7 +134,7 @@ If you have enabled a third party APT repository but found yourself in a situati
 
 The first step is to remove the files created in the steps above. These are:
 
-* The sources.list file, under `/etc/apt/sources.list.d/`.
+* The `.sources` (or `.list`) file, under `/etc/apt/sources.list.d/`.
 * The package pinning preference, under `/etc/apt/preferences.d/`.
 * If the third party APT repository does not provide the GPG key in a package, then you can also remove it manually from `/usr/share/keyrings/`.
 


### PR DESCRIPTION
### Description

- specify deb822 as the default format for source files
- change the examples to resolute

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [n/a] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

Thank you for contributing to the Ubuntu Server documentation!

you welcome
