### PR TITLE
Separate linkcheck from doc checks, make it weekly

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     paths:
       - 'docs/**'   # Only run on changes to the docs directory
+  workflow_call:
+    outputs:
+      spellcheck-result:
+        description: "Result of the spelling check"
+        value: ${{ jobs.docchecks.outputs.result_spelling }}
+      woke-result:
+        description: "Result of the inclusive language check"
+        value: ${{ jobs.docchecks.outputs.result_woke }}
 
   workflow_dispatch:
     # Manual trigger
@@ -16,8 +24,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  documentation-checks:
-    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
-    with:
-      working-directory: 'docs'
-      fetch-depth: 0
+  docchecks:
+    name: Run documentation checks
+    runs-on: 'ubuntu-latest'
+    outputs:
+      result_spelling: ${{ steps.spellcheck-step.outcome }}
+      result_woke: ${{ steps.woke-step.outcome }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Spell Check
+        id: spellcheck-step
+        if: success() || failure()
+        uses: canonical/documentation-workflows/spellcheck@main
+        with:
+          working-directory: 'docs'
+          install-target: 'install'
+          spelling-target: 'spelling'
+          makefile: 'use-default'
+
+      - name: Inclusive Language Check
+        id: woke-step
+        if: success() || failure()
+        uses: canonical/documentation-workflows/inclusive-language@main
+        with:
+          working-directory: 'docs'
+          install-target: 'install'
+          woke-target: 'woke'
+          makefile: 'use-default'

--- a/.github/workflows/weekly-linkcheck.yml
+++ b/.github/workflows/weekly-linkcheck.yml
@@ -1,0 +1,37 @@
+name: Weekly link check
+
+on:
+  schedule:
+    - cron: "0 1 * * 4" # Runs at 01:00 AM on every Wednesday
+  workflow_call:
+    outputs:
+      linkcheck-result:
+        description: "Result of the link check"
+        value: ${{ jobs.docchecks.outputs.result_links }}
+
+jobs:
+  docchecks:
+    name: Run documentation checks
+    runs-on: 'ubuntu-latest'
+    outputs:
+      result_links: ${{ steps.linkcheck-step.outcome }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Link Check
+        id: linkcheck-step
+        if: success() || failure()
+        uses: canonical/documentation-workflows/linkcheck@main
+        with:
+          working-directory: 'docs'
+          install-target: 'install'
+          linkcheck-target: 'linkcheck'
+          makefile: 'use-default'


### PR DESCRIPTION
### Description

The linkcheck is becoming increasingly fragile and flaky, and often reports breakages that aren't valid. To avoid adding an ever-increasing number of domains to the ignore list, which risks us having broken links that we will never pick up, we will just disable the check on PR runs.

Instead, we'll do a once-a-week linkcheck to ensure that we get regular updates on genuine breakages.

Spelling and woke checks will continue to be run on PRs as normal. Linkcheck can still be run locally at any time and as needed.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Big thanks to Robert for [his implementation](https://github.com/ubuntu/ubuntu-project-docs/pull/154) of this split in the Ubuntu Project docs.