### PR TITLE
Remove chef from the config managers list

### DIFF
--- a/docs/explanation/software/config-managers.md
+++ b/docs/explanation/software/config-managers.md
@@ -9,7 +9,7 @@ myst:
 
 There are several configuration management tools that can help manage IT
 infrastructure, typically through automating configuration and deployment
-processes. The most popular options are Ansible and Puppet.
+processes. Some popular options are Ansible and Puppet.
 
 Although they can be complex to set up initially, they have a clear advantage
 in environments where scalability and consistency are important. Both of


### PR DESCRIPTION
### Description

It's not in Ubuntu for a while now - it's not even supported in any release anymore:

```
 rmadison chef
 chef | 11.8.2-2               | trusty/universe | source, all
 chef | 12.3.0-3ubuntu1        | xenial/universe | source, all
 chef | 12.14.60-3ubuntu1      | bionic/universe | source, all
 chef | 15.8.25.3.gcf41df6a2-6 | focal/universe  | source, all
```

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [n/a] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

Thank you for contributing to the Ubuntu Server documentation!

you welcome