### PR TITLE
User management improvements

### DIFF
--- a/docs/how-to/security/user-management.md
+++ b/docs/how-to/security/user-management.md
@@ -345,7 +345,7 @@ Remove or rename the directory `.ssh/` in the user's home folder to prevent furt
 Be sure to check for any established SSH connections by the disabled account, as it is possible they may have existing inbound or outbound connections -- then `pkill` any that are found.
 
 ```bash
-who | grep username  (to get the pts/# terminal)
+w | grep username  (to get the pts/# terminal)
 sudo pkill -f pts/#
 ```
 


### PR DESCRIPTION
### Description

Minor corrections related to changes in behavior.

An alternative to `w | grep <username> && pkill -f pts/<something>` is to use `loginctl terminate-user <username>` instead, but I'm not sure if both behave the same way in all situations.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.