### PR TITLE
Add manpage link for fence_mpath in fence agents explanation

### DIFF
--- a/docs/explanation/high-availability/pacemaker-fence-agents.md
+++ b/docs/explanation/high-availability/pacemaker-fence-agents.md
@@ -106,7 +106,7 @@ $ pcs stonith create $RESOURCE_NAME fence_mpath \
 
 The `$NODE1_RES_KEY` is the reservation key used by this node 1 (same for the others node with access to the multipath device), please make sure you have `reservation_key <key>` in the `default` section inside `/etc/multipath.conf` and the multipathed service was reloaded after it.
 
-This is one way to set up `fence_mpath`, for more information please check its manual page.
+This is one way to set up `fence_mpath`, for more information please check {manpage}`its manual page <fence_mpath(8)>`.
 
 ## `fence_sbd`
 


### PR DESCRIPTION
### Description

It was missing.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [n/a] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

Thank you for contributing to the Ubuntu Server documentation!

you welcome