### PR TITLE
Point HA links to the latest documentation

### DIFF
--- a/docs/explanation/intro-to/high-availability.md
+++ b/docs/explanation/intro-to/high-availability.md
@@ -157,10 +157,9 @@ Packages in this list aren't necessarily **HA** related packages, but they play 
 The Server documentation is not intended to document every option for all the HA related software described in this page. More complete documentation can be found upstream at:
 
 - ClusterLabs
-  - [Clusters From Scratch](https://clusterlabs.org/projects/pacemaker/doc/deprecated/)
-  - [Managing Pacemaker Clusters](https://clusterlabs.org/projects/pacemaker/doc/deprecated/en-US/Pacemaker/2.0/html/Clusters_from_Scratch/index.html)
-  - [Pacemaker Configuration Explained](https://clusterlabs.org/projects/pacemaker/doc/deprecated/en-US/Pacemaker/2.0/html/Pacemaker_Explained/index.html)
-  - [Pacemaker Remote - Scaling HA Clusters](https://clusterlabs.org/projects/pacemaker/doc/deprecated/en-US/Pacemaker/2.0/html/Pacemaker_Remote/index.html)
+  - [Clusters From Scratch](https://clusterlabs.org/projects/pacemaker/doc/3.0/Clusters_from_Scratch/html/)
+  - [Managing Pacemaker Clusters](https://clusterlabs.org/projects/pacemaker/doc/3.0/Pacemaker_Administration/html/)
+  - [Pacemaker Configuration Explained](https://clusterlabs.org/projects/pacemaker/doc/3.0/Pacemaker_Explained/html/)
 - Other
   - [Ubuntu Bionic HA in Shared Disk Environments (Azure)](https://discourse.ubuntu.com/t/ubuntu-high-availability-corosync-pacemaker-shared-disk-environments/14874)
 


### PR DESCRIPTION
### Description

Change the deprecated docs links for the proper ones now that we have Pacemaker 3.0 in Ubuntu.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [n/a] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

Thank you for contributing to the Ubuntu Server documentation!

you welcome