### PR TITLE
NFS changes

### DIFF
--- a/docs/how-to/networking/install-nfs.md
+++ b/docs/how-to/networking/install-nfs.md
@@ -51,9 +51,9 @@ Apply the new config via:
 
 You can replace `*` with one of the {term}`hostname` formats. Make the hostname declaration as specific as possible so unwanted systems cannot access the NFS mount. Be aware that `*.hostname.com` will match `foo.hostname.com` and all its subdomains, as the `*` character also matches dots.
 
-The *`sync`*/*`async`* options control whether changes are guaranteed to be committed to stable storage before replying to requests. *`async`* thus gives a performance benefit but risks data loss or corruption. Some older versions of `exportfs` will issue a warning if this option left unspecified.
+The *`sync`*/*`async`* options control whether changes are guaranteed to be committed to stable storage before replying to requests. *`async`* thus gives a performance benefit but risks data loss or corruption. Some older versions of `exportfs` will issue a warning if this option is left unspecified.
 
-*`subtree_check`* and *`no_subtree_check`* enables or disables a security verification that subdirectories a client attempts to mount for an exported {term}`filesystem` are ones they're permitted to do so. This verification step has some performance implications for some use cases, such as home directories with frequent file renames. Read-only filesystems are more suitable to enable *`subtree_check`* on. In some older versions, `exportfs` will warn if this option left unspecified.
+*`subtree_check`* and *`no_subtree_check`* enables or disables a security verification that subdirectories a client attempts to mount for an exported {term}`filesystem` are ones they're permitted to do so. This verification step has some performance implications for some use cases, such as home directories with frequent file renames. Read-only filesystems are more suitable to enable *`subtree_check`* on. In some older versions, `exportfs` will warn if this option is left unspecified.
 
 There are a number of optional settings for NFS mounts for tuning performance, tightening security, or providing conveniences. These settings each have their own trade-offs so it is important to use them with care, only as needed for the particular use case. *`no_root_squash`*, for example, adds a convenience to allow root-owned files to be modified by any client system's root user; in a multi-user environment where executables are allowed on a shared mount point, this could lead to security problems.
 
@@ -96,11 +96,11 @@ Therefore, issue the command:
 sudo systemctl daemon-reload
 ```
 
-## Advanced Configuration
+## Advanced configuration
 
 NFS is comprised of several services, both on the server and the client. Each one of these services can have its own default configuration, and depending on the Ubuntu Server release you have installed, this configuration is done in different files, and with a different syntax.
 
-All NFS related services read a single configuration file: `/etc/nfs.conf`. This is a INI-style config file, see the {manpage}`nfs.conf(5)` manual page for details. Furthermore, there is a `/etc/nfs.conf.d` directory which can hold `*.conf` snippets that can override settings from previous snippets or from the `nfs.conf` main config file itself.
+All NFS related services read a single configuration file: `/etc/nfs.conf`. This is an INI-style config file, see the {manpage}`nfs.conf(5)` manual page for details. Furthermore, there is a `/etc/nfs.conf.d` directory which can hold `*.conf` snippets that can override settings from previous snippets or from the `nfs.conf` main config file itself.
 
 There is a new command-line tool called {manpage}`nfsconf(8)` which can be used to query or even set configuration parameters in `nfs.conf`. In particular, it has a `--dump` parameter which will show the effective configuration including all changes done by `/etc/nfs.conf.d/*.conf` snippets.
 


### PR DESCRIPTION
### Description
This updates the NFS installation docs with fixes and simplifications.

In particular, it moved the focal notes and exceptions to the end, since focal is EOL, and dropped some focal-specific explanations which were not complete either. This simplifies the docs as it focus on "current" NFS, which is the same since jammy.

I tested all these changes, except a release upgrade from focal.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
