### PR TITLE
Change link in CUPS page to Debian Printing wiki

### DIFF
--- a/docs/how-to/networking/cups-print-server.md
+++ b/docs/how-to/networking/cups-print-server.md
@@ -106,4 +106,4 @@ If you make this change, remember to change it back once you've solved your prob
 
 * [CUPS Website](http://www.cups.org/)
 
-* [Debian Open-iSCSI page](https://wiki.debian.org/SAN/iSCSI/open-iscsi)
+* [Debian Printing Wiki](https://wiki.debian.org/Printing)


### PR DESCRIPTION
### Description

A link to open-iscsi was there before :|

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [n/a] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

Thank you for contributing to the Ubuntu Server documentation!

you welcome