### PR TITLE
chrony: drop fixed bug

### DIFF
--- a/docs/how-to/networking/serve-ntp-with-chrony.md
+++ b/docs/how-to/networking/serve-ntp-with-chrony.md
@@ -105,10 +105,6 @@ Certain `chronyc` commands are privileged and cannot be run via the network with
 
 `Chrony` supports various PPS types natively. It can use kernel PPS API as well as Precision Time Protocol (PTP) hardware clocks. Most general GPS receivers can be leveraged via {term}`GPSD`. The latter (and potentially more) can be accessed via **SHM** or via a **socket** (recommended). All of the above can be used to augment `chrony` with additional high quality time sources for better accuracy, {term}`jitter`, drift, and longer- or shorter-term accuracy. Usually, each kind of clock type is good at one of those, but non-perfect at the others. For more details on configuration see some of the external PPS/GPSD resources listed below.
 
-```{note}
-As of the release of 20.04, there was a bug which - until fixed - you might want to [add this content](https://bugs.launchpad.net/ubuntu/+source/gpsd/+bug/1872175/comments/21) to your `/etc/apparmor.d/local/usr.sbin.gpsd`.
-```
-
 ### Example configuration for GPSD to feed `chrony`
 
 For the installation and setup you will first need to run the following command in your terminal window:


### PR DESCRIPTION
It was not only fixed later but also SRUed to Focal. So as of today none should be affected and hence we can drop the old hint entirely.