### PR TITLE
OpenSSH cryptography improvements

### DIFF
--- a/docs/explanation/crypto/openssh-crypto-configuration.md
+++ b/docs/explanation/crypto/openssh-crypto-configuration.md
@@ -53,7 +53,7 @@ Here are the configuration settings that control the cryptographic algorithms se
     List of Message Authentication Code algorithms, used for data integrity protection. The `-etm` versions calculate the MAC after encryption and are considered safer. Examples include `hmac-sha2-256` and `hmac-sha2-512-etm@openssh.com`.
 
 * `GSSAPIKexAlgorithms`
-    This option is not available in OpenSSH upstream, and is [provided via a patch](https://git.launchpad.net/ubuntu/+source/openssh/tree/debian/patches/gssapi.patch?h=applied/ubuntu/jammy-devel) that Ubuntu and many other Linux Distributions carry. It lists the key exchange (kex) algorithms that are offered for {term}`Generic Security Services Application Program Interface (GSSAPI) <GSSAPI>` key exchange, and only applies to connections using GSSAPI. Examples include `gss-gex-sha1-` and `gss-group14-sha256-`.
+    This option is not available in OpenSSH upstream, and is [provided via a patch](https://git.launchpad.net/ubuntu/+source/openssh/tree/debian/patches/gssapi.patch) that Ubuntu and many other Linux Distributions carry. It lists the key exchange (kex) algorithms that are offered for {term}`Generic Security Services Application Program Interface (GSSAPI) <GSSAPI>` key exchange, and only applies to connections using GSSAPI. Examples include `gss-gex-sha1-` and `gss-group14-sha256-`.
 
 * `KexAlgorithms`
     List of available key exchange (kex) algorithms. Examples include `curve25519-sha256` and `sntrup761x25519-sha512@openssh.com`.


### PR DESCRIPTION
### Description

Show usage of configuration snippets instead of modifying the `/etc/ssh/sshd_config` file directly. Also changes the default ciphers and GSS patch URL from jammy to resolute.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.