### PR TITLE
Fix link to java.security configuration file

### DIFF
--- a/docs/explanation/crypto/java-cryptography-configuration.md
+++ b/docs/explanation/crypto/java-cryptography-configuration.md
@@ -37,7 +37,7 @@ This is a very large file, with many options and comments. Its structure is simp
 * `jdk.certpath.disabledAlgorithms`: Restrictions on algorithms and key lengths used in certificate path processing.
 * `jdk.tls.disabledAlgorithms`: Restrictions on algorithms and key lengths used in SSL/TLS connections.
 
-The list of restrictions has its own format which allows for constructs that disable whole families of algorithms, key sizes, usage, and more. The [`java.security` configuration file](https://git.launchpad.net/ubuntu/+source/openjdk-lts/tree/src/java.base/share/conf/security/java.security) has comments explaining this syntax with some examples.
+The list of restrictions has its own format which allows for constructs that disable whole families of algorithms, key sizes, usage, and more. The [`java.security` configuration file](https://git.launchpad.net/ubuntu/+source/openjdk-lts/tree/src/java.base/share/conf/security/java.security/#n520) has comments explaining this syntax with some examples.
 
 Changes to these security settings can be made directly in the `/etc/java-<VERSION>-openjdk/security/java.security` file, or in an alternate file that can be specified to a Java application by setting the `java.security.properties` value. For example, if your Java application is called `myapp.java`, you can invoke it as shown below to specify an additional security properties file:
 


### PR DESCRIPTION
### Description

Reintroduce the section header I inadvertently removed when reviewing #596 so it still skips to the correct place even with the version header removed.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

