### PR TITLE
Fix indentation of yaml code blocks

### DIFF
--- a/docs/how-to/active-directory/join-a-domain-with-winbind-preparation.md
+++ b/docs/how-to/active-directory/join-a-domain-with-winbind-preparation.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: Prepare to join an Active Directory domain with winbind by configuring DNS resolver, installing packages, and planning identity mapping.
+    description: Prepare to join an Active Directory domain with winbind by completing tasks in common to all identity mapping backends prior to selecting one.
 ---
 
 (join-a-domain-with-winbind-preparation)=


### PR DESCRIPTION
### Description
The indentation was incorrect, and that's fatal in yaml files. Also quick update to the meta tag.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [ ] My pull request is linked to an existing issue (if applicable).
- [ ] I have tested my changes, and they work as expected.
