### PR TITLE
Cleanup and reorganize redirects file

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -13,8 +13,7 @@
 # redirect/from/file/ redirect/to/file/
 
 # Some of the redirects capture traffic from the old Discourse docs and route
-# them to the right pages in the RTD docs. These redirects have "# Discourse"
-# after them.
+# them to the right pages in the RTD docs.
 
 # =============================================================================
 # Tutorials


### PR DESCRIPTION
### Description

After monitoring the 404ing pages in the week since our documentation sprint (where several pages were split/renamed/removed/moved) I noticed some 404s being reported in RTD.

This PR adds redirects to capture that traffic, and additionally organizes the file to make it easier to navigate. Redirects are now grouped by topic, and then by target page.

~~I've also marked each redirect as to whether it's originally from Discourse, or has been added since we moved to RTD.~~ Lol, nope. It turns out rediraffe doesn't like comments on the end of the redirect lines.

Links from/to RTD pages must have trailing slashes (`/`) at the end of *both* the "from" and "to" paths. Links from Discourse only need a slash at the end of the "to" path.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
