### PR TITLE
Document Docker snap as an alternative installation option

### DIFF
--- a/docs/how-to/containers/docker-for-system-admins.md
+++ b/docs/how-to/containers/docker-for-system-admins.md
@@ -17,9 +17,9 @@ First, install Docker if it’s not already installed:
 $ sudo apt-get install -y docker.io docker-compose
 ```
 :::{note}
-This guide uses the Docker packages provided by Ubuntu (`docker.io`), which are supported by Canonical.
+This guide uses the Docker packages provided by Ubuntu (`docker.io`), which are supported by Canonical. The instructions and examples below are written for these packages.
 
-Canonical also provides an [official Docker snap](https://snapcraft.io/docker) that can be used as an alternative.
+Canonical also provides a [Docker snap](https://snapcraft.io/docker). This guide does not cover the snap installation path.
 :::
 
 ## Configuring storage


### PR DESCRIPTION
### Description

Adds a note to the Docker installation guide mentioning the official Docker snap as an alternative installation option.

### Related Issue
- Fixes: #341 