### PR TITLE
Add redirects for some 404 pages

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -439,6 +439,7 @@ security-automatic-updates how-to/software/automatic-updates/
 service-openssh how-to/security/openssh-server/
 openssh-server how-to/security/openssh-server/
 security-ssh how-to/security/openssh-server/
+how-to/security/openssh/ how-to/security/openssh-server/
 
 service-openvpn how-to/security/install-openvpn/
 how-to-install-and-use-openvpn how-to/security/install-openvpn/
@@ -595,6 +596,8 @@ multipath-configuration-examples explanation/multipath/multipath-configuration-e
 
 device-mapper-multipathing-usage-debug explanation/multipath/common-multipath-tasks-and-procedures/
 common-multipath-tasks-and-procedures explanation/multipath/common-multipath-tasks-and-procedures/
+
+introduction-to-device-mapper-multipathing explanation/intro-to/multipath
 
 # =============================================================================
 # Performance


### PR DESCRIPTION
### Description

Discovered some additional 404ing pages via Google Search console that needed redirects set up.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
