### PR TITLE
Add new URLs to ignore list for linkchecker

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -244,6 +244,8 @@ linkcheck_ignore = [
     "https://git.launchpad.net/*",
     "https://linuxcontainers.org/*",
     "https://wiki.syslinux.org/*",
+    "https://www.openstack.org/*",
+    "https://web.archive.org/web/20241130024605/http://networktimesecurity.org/"
     # Rate-limited domains that cause delays
     r"http://www\.gnu\.org/software/.*",
     r"https://github\.com/.*/blob/.*",


### PR DESCRIPTION
### Description

Adding more links to the ignore list. They are breaking the linkchecker but the URLs are valid and aren't actually broken.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

