### PR TITLE
Remove broken NFS link

### DIFF
--- a/docs/how-to/networking/install-nfs.md
+++ b/docs/how-to/networking/install-nfs.md
@@ -301,9 +301,3 @@ The conversion tool can be run manually to gather more information about the err
 If all goes well, as it should in most cases, the system will have `/etc/nfs.conf` with the defaults, and `/etc/nfs.conf.d/local.conf` with the changes. You can merge these two together manually, and then delete `local.conf`, or leave it as is. Just keep in mind that `/etc/nfs.conf` is not the whole story: always inspect `/etc/nfs.conf.d` as well, as it may contain files overriding the defaults.
 
 You can always run `nfsconf --dump` to check the final settings, as it merges together all configuration files and shows the resulting non-default settings.
-
-
-
-## References
-
-* [Linux NFS wiki](https://linux-nfs.org/wiki/index.php/Main_Page)


### PR DESCRIPTION
### Description

The "official" NFS site no longer seems to exist and is fully broken in the linkchecker. I can't find an official replacement, so removing the link entirely.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
