### PR TITLE
pin to specific version of starter pack

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Canonical theme (still needed for Furo theme and custom templates)
-canonical-sphinx==1.3.1
+canonical-sphinx==0.3.0
 
 # Extensions previously auto-loaded by canonical-sphinx
 myst-parser~=4.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Canonical theme (still needed for Furo theme and custom templates)
-canonical-sphinx>=0.5.1
+canonical-sphinx==1.3.1
 
 # Extensions previously auto-loaded by canonical-sphinx
 myst-parser~=4.0


### PR DESCRIPTION
### Description

In the last couple of weeks (since updating to the new starter pack) a number of changes made either to the SP itself, or to its bundled extensions, have been automatically introduced to the docs [1] without warning and without the opportunity to test compatibility.

This PR pins us to the version of the SP that we upgraded to at the start of the 26.04 cycle, to ensure that no more sudden and unexpected changes can be introduced.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

[1] The specific change that most concerned me was the change to how the workflows are handled that meant our own setup (linkcheck run once a week, with a bunch of exceptions to ignore rate-limited sites) was ignored in favour of the SP default of running the linkcheck on every PR, and the ignore list being ignored as well (so the check was taking over 10 minutes before failing).

---

Thank you for contributing to the Ubuntu Server documentation!
