### PR TITLE
Change DNS zone type from secondary to slave

### DIFF
--- a/docs/how-to/networking/install-dns.md
+++ b/docs/how-to/networking/install-dns.md
@@ -204,13 +204,13 @@ Next, on the secondary server, install the `bind9` package the same way as on th
 
 ```
 zone "example.com" {
-    type secondary;
+    type slave;
     file "db.example.com";
     masters { 192.168.1.10; };
 };        
           
 zone "1.168.192.in-addr.arpa" {
-    type secondary;
+    type slave;
     file "db.192";
     masters { 192.168.1.10; };
 };


### PR DESCRIPTION
```markdown
# BIND9 Secondary Server Configuration Error

## Description
Encountered difficulty in configuring the secondary server for BIND9.

## Troubleshooting Steps
1. Installed BIND9 on the secondary server:
   ```
        sudo apt install bind9
   ```

2. Edited the `/etc/bind/named.conf.local` file on the primary server to add the forward and reverse zone configurations.

3. Solution
The correct configuration for the secondary zone should be as follows:
```zone "example.com" {
    type master;
    file "db.example.com";
    allow-transfer { 192.168.1.10; };
};

zone "1.168.192.in-addr.arpa" {
    type master;
    file "db.192";
    allow-transfer { 192.168.1.10; };
};

# On the secondary server
zone "example.com" {
    type slave;  # Corrected terminology
    masters { 192.168.1.10; };
};
## References
- [BIND9 Documentation](https://bind9.readthedocs.io)
```