### PR TITLE
Disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
### Description

This PR disables the "blank issue" option when creating a new issue from the button in the repo.

Readers who report an issue via the "Give feedback" button in the docs are shown the feedback template by default, and these issues tend to provide more helpful information. By contrast, creating an issue via the repo "new issue" button are asked to choose between using the feedback template and a blank issue. More often than not, people choose the blank issue option, but then we miss out on crucial information that would make their feedback actionable.

Since the feedback template leads to better issues (more/better info), we should show the feedback template by default. Users can still delete the template contents, of course, but we should err on the side of providing more guidance - helping our users to help us.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
