### PR TITLE
Update PDF link for current Ubuntu Server documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ page.
 Thinking about using Ubuntu Server for your next project? [Get in touch!](https://ubuntu.com/server/contact-us?product=server)
 
 **PDF versions**
-: [Current PDF](https://documentation.ubuntu.com/_/downloads/server/en/latest/pdf/) (for Ubuntu 20.04 LTS onward)
+: [Current PDF](https://ubuntu.com/server/docs/_/downloads/en/latest/pdf/) (for Ubuntu 20.04 LTS onward)
 : [Ubuntu 18.04 LTS PDF](https://assets.ubuntu.com/v1/8f8ea0cf-18-04-serverguide.pdf)
 
 ```{toctree}


### PR DESCRIPTION
### Description

Hangover from the migration last week, this link still pointed to the old (docs.u.c) version of the PDF. For some reason it wasn't caught in the redirects.

---

### Related Issue

- Fixes: #666

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
