### PR TITLE
replace old URL with the new one

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: Page URL
       description: Please enter the URL of the page you are referring to.
-      placeholder: https://documentation.ubuntu.com/server/
+      placeholder: https://ubuntu.com/server/docs/
     validations:
       required: true
   - type: checkboxes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ Provide the desired commit message below:
 
 ### Checklist
 
-- [ ] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
+- [ ] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
 - [ ] My pull request is linked to an existing issue (if applicable).
 - [ ] I have tested my changes, and they work as expected.
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ with any page.
 * [Get support](https://ubuntu.com/support/community-support)
 * [Join the Discourse forum](https://discourse.ubuntu.com/c/server/17)
 * [Download Ubuntu Server](https://ubuntu.com/server)
-* [Find out how to contribute](https://documentation.ubuntu.com/server/contributing/)
+* [Find out how to contribute](https://ubuntu.com/server/docs/contributing/)
 
 ## Offline version
 
-You can [build this documentation locally](https://documentation.ubuntu.com/server/contributing/build-locally), or you can
-access [the PDF version](https://documentation.ubuntu.com/server/) of this
+You can [build this documentation locally](https://ubuntu.com/server/docs/contributing/build-locally), or you can
+access [the PDF version](https://ubuntu.com/server/docs/_/downloads/en/latest/pdf/) of this
 documentation from Read the Docs.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -12,7 +12,7 @@ contributor to open source projects, no matter your level of experience!
 
 The Ubuntu Server documentation is
 [hosted in GitHub](https://github.com/canonical/ubuntu-server-documentation) and
-[rendered on Read the Docs](https://documentation.ubuntu.com/server/). It is a
+[rendered on Read the Docs](https://ubuntu.com/server/docs/). It is a
 collaborative effort between Canonical and the Ubuntu community. There are many
 ways to contribute to the Ubuntu Server documentation, including many {ref}`options
 that don't require any coding <contrib-types>`.

--- a/docs/contributing/local-development.md
+++ b/docs/contributing/local-development.md
@@ -77,7 +77,7 @@ as typos or minor corrections, it can be easier to edit pages directly through
 This approach is valid whether you are fixing a single typo, or making multiple
 changes to a single file.
 
-1. Navigate to the page you want to edit [in the documentation](https://documentation.ubuntu.com/server)
+1. Navigate to the page you want to edit [in the documentation](https://ubuntu.com/server/docs)
 1. Click the "Edit on GitHub" button (pencil icon) at the top of the page (you will be prompted to create a GitHub account if you don't already have one)
 1. Make your changes in the GitHub web editor and save them
 1. Select "Create a new branch for this commit and start a pull request"
@@ -263,7 +263,7 @@ redirects = {
 
 When you set up a redirect in this way, the path of the source file you're
 redirecting from should include everything *after* the base URL
-(https://documentation.ubuntu.com/server).
+(https://ubuntu.com/server/docs).
 
 (submit-work)=
 ## Submitting your pull request


### PR DESCRIPTION
### Description

Since the domains have migrated and everything is stable and good, this PR updates all the links to the old URL that I could find in the docs, to the new one

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://documentation.ubuntu.com/server/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
