### PR TITLE
[chore] Fix linkchecker failure

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,6 +248,7 @@ linkcheck_ignore = [
     "https://wiki.syslinux.org/*",
     "https://www.openstack.org/*",
     "https://web.archive.org/web/20241130024605/http://networktimesecurity.org/",
+    "https://www.intel.com/*",
     # Rate-limited domains that cause delays
     "http://www.gnu.org/software/*",
     "https://github.com./*",


### PR DESCRIPTION
### Description

The intel TDX overview link at the top of our [TDX page](https://ubuntu.com/server/docs/how-to/virtualisation/intel-tdx/) is correct, but blocking bot traffic, so it's showing as "broken" in the linkchecker. Adding to ignore list.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
