### PR TITLE
openvpn: document usage of tls-crypt instead of tls-auth

### DIFF
--- a/docs/how-to/security/install-openvpn.md
+++ b/docs/how-to/security/install-openvpn.md
@@ -115,6 +115,12 @@ dh dh.pem
 tls-crypt ta.key
 ```
 
+:::{note}
+The `tls-crypt` option was introduced in OpenVPN 2.4.0. If you are running an
+Ubuntu Server release older than 18.04 LTS (Bionic Beaver), please use
+`tls-auth ta.key 0` instead.
+:::
+
 Complete this set with a TLS Authentication (TA) key in `/etc/openvpn` for `tls-crypt` like this:
 
 ```bash
@@ -255,6 +261,12 @@ cert myclient1.crt
 key myclient1.key
 tls-crypt ta.key
 ```
+
+:::{note}
+The `tls-crypt` option was introduced in OpenVPN 2.4.0. If you are running an
+Ubuntu Server release older than 18.04 LTS (Bionic Beaver), please use
+`tls-auth ta.key 1` instead.
+:::
 
 And you have to specify the OpenVPN server name or address. Make sure the keyword **`client`** is in the config file, since that's what enables client mode.
 

--- a/docs/how-to/security/install-openvpn.md
+++ b/docs/how-to/security/install-openvpn.md
@@ -112,10 +112,10 @@ ca ca.crt
 cert myservername.crt
 key myservername.key
 dh dh.pem
-tls-auth ta.key 0
+tls-crypt ta.key
 ```
 
-Complete this set with a TLS Authentication (TA) key in `/etc/openvpn` for `tls-auth` like this:
+Complete this set with a TLS Authentication (TA) key in `/etc/openvpn` for `tls-crypt` like this:
 
 ```bash
 sudo openvpn --genkey secret ta.key
@@ -253,7 +253,7 @@ Copy the following client keys and certificate files you created in the section 
 ca ca.crt
 cert myclient1.crt
 key myclient1.key
-tls-auth ta.key 1
+tls-crypt ta.key
 ```
 
 And you have to specify the OpenVPN server name or address. Make sure the keyword **`client`** is in the config file, since that's what enables client mode.
@@ -412,7 +412,6 @@ If the above didn't work for you, check the following:
 - Client and server must use same protocol and port, e.g. UDP port 1194, see `port` and `proto` config options.
 - Client and server must use the same compression configuration, see `comp-lzo` config option.
 - Client and server must use same config regarding bridged vs. routed mode, see `server vs server-bridge` config option
-- Client must use the config `tls-auth` with index `1` (example client config: `tls-auth ta.key 1`), but server must use `tls-auth` with index `0` (example server config: `tls-auth ta.key 0`).
 
 ## Advanced configuration
 


### PR DESCRIPTION
### Description

Using `tls-crypt` provides encryption to the key exchange phase before the TLS session is established.

I tested this by creating two Resolute LXD containers and configuring one as client and one as server as described in the guide. Then, I switched to `tls-crypt` and verified that the connection was still working. Unsure if any more testing is needed.

I'll also verify that the output of systemd commands are up-to-date, so I'm opening this PR as draft for now.

Do note that this option was introduced in OpenVPN 2.4.0, which is present in Ubuntu releases >= Bionic. Do we need to keep the old `tls-auth` configuration documented somewhere? Xenial is already EOL, and ESM is ending very soon.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.