### PR TITLE
Add network access control section to CUPS guide

### DIFF
--- a/docs/how-to/networking/cups-print-server.md
+++ b/docs/how-to/networking/cups-print-server.md
@@ -107,7 +107,7 @@ To allow access from your local network add or update the `<Location>` blocks in
 
 Replace `192.168.10.*` with the subnet of your local network.
 
-If you have a [firewall](https://ubuntu.com/server/docs/how-to/security/firewalls/) enabled (e.g. `ufw`), you must also open port 631 to allow incoming connections:
+If you have a {ref}`firewall <firewalls>` enabled (e.g. `ufw`), you must also open port 631 to allow incoming connections:
 
 ```bash
 sudo ufw allow 631/tcp

--- a/docs/how-to/networking/cups-print-server.md
+++ b/docs/how-to/networking/cups-print-server.md
@@ -107,7 +107,7 @@ To allow access from your local network add or update the `<Location>` blocks in
 
 Replace `192.168.10.*` with the subnet of your local network.
  
-If you have a firewall enabled (e.g. `ufw`), you must also open port 631 to allow incoming connections:
+If you have a [firewall](https://ubuntu.com/server/docs/how-to/security/firewalls/) enabled (e.g. `ufw`), you must also open port 631 to allow incoming connections:
 
 ```bash  
 sudo ufw allow 631/tcp

--- a/docs/how-to/networking/cups-print-server.md
+++ b/docs/how-to/networking/cups-print-server.md
@@ -74,6 +74,45 @@ For more examples of configuration directives in the CUPS server configuration f
 man cupsd.conf
 ```
 
+### Configure network access
+ 
+Configuring CUPS to listen on a network interface is not sufficient on its own to make it accessible from other hosts. CUPS also enforces access control through `<Location>` directives in `cupsd.conf`, which by default restrict access to `localhost` only. Without updating these directives, remote hosts will receive a **"Forbidden"** error when trying to reach the web interface or submit print jobs.
+ 
+To allow access from your local network add or update the `<Location>` blocks in `/etc/cups/cupsd.conf` as follows:
+ 
+```text
+# Allow access to the web interface from the local network
+<Location />
+  Order allow,deny
+  Allow localhost
+  Allow 192.168.10.*
+</Location>
+ 
+# Allow access to the administration pages from the local network
+<Location /admin>
+  Order allow,deny
+  Allow localhost
+  Allow 192.168.10.*
+</Location>
+ 
+# Allow access to the admin configuration from the local network
+<Location /admin/conf>
+  AuthType Default
+  Require user @SYSTEM
+  Order allow,deny
+  Allow localhost
+  Allow 192.168.10.*
+</Location>
+```
+
+Replace `192.168.10.*` with the subnet of your local network.
+ 
+If you have a firewall enabled (e.g. `ufw`), you must also open port 631 to allow incoming connections:
+
+```bash  
+sudo ufw allow 631/tcp
+```
+
 ## Post-configuration restart
 
 Whenever you make changes to the `/etc/cups/cupsd.conf` configuration file, you'll need to restart the CUPS server by typing the following command at a terminal prompt:

--- a/docs/how-to/networking/cups-print-server.md
+++ b/docs/how-to/networking/cups-print-server.md
@@ -75,11 +75,11 @@ man cupsd.conf
 ```
 
 ### Configure network access
- 
+
 Configuring CUPS to listen on a network interface is not sufficient on its own to make it accessible from other hosts. CUPS also enforces access control through `<Location>` directives in `cupsd.conf`, which by default restrict access to `localhost` only. Without updating these directives, remote hosts will receive a **"Forbidden"** error when trying to reach the web interface or submit print jobs.
- 
+
 To allow access from your local network add or update the `<Location>` blocks in `/etc/cups/cupsd.conf` as follows:
- 
+
 ```text
 # Allow access to the web interface from the local network
 <Location />
@@ -87,14 +87,14 @@ To allow access from your local network add or update the `<Location>` blocks in
   Allow localhost
   Allow 192.168.10.*
 </Location>
- 
+
 # Allow access to the administration pages from the local network
 <Location /admin>
   Order allow,deny
   Allow localhost
   Allow 192.168.10.*
 </Location>
- 
+
 # Allow access to the admin configuration from the local network
 <Location /admin/conf>
   AuthType Default
@@ -106,10 +106,10 @@ To allow access from your local network add or update the `<Location>` blocks in
 ```
 
 Replace `192.168.10.*` with the subnet of your local network.
- 
+
 If you have a [firewall](https://ubuntu.com/server/docs/how-to/security/firewalls/) enabled (e.g. `ufw`), you must also open port 631 to allow incoming connections:
 
-```bash  
+```bash
 sudo ufw allow 631/tcp
 ```
 


### PR DESCRIPTION
### Description

Adds a new "Configure network access" subsection immediately after "Configure Listen" in the CUPS print server how-to guide.

The guide currently explains how to configure the `Listen` directive to make CUPS reachable on a network interface, but does not document the `<Location>` directives that control which hosts are actually allowed to connect. Without this step, users who correctly configure `Listen` still receive a **Forbidden** error from remote hosts, with no obvious indication that the cause is an application-level access control rather than a network or firewall issue.

The new section explains why `Listen` alone is not sufficient, describes the default behaviour of `<Location>` blocks, provides a working configuration example for the three relevant blocks (`/`, `/admin`, `/admin/conf`), and includes a note about opening port 631 in `ufw` if a firewall is active.

---

### Related Issue

- Fixes: #686 

---

### Commit Message for Squash Merge

[how-to] Add network access control (Location directives) to CUPS guide

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

**AI disclosure:** I used Claude (Anthropic) as a drafting aid to help structure and word the new section. I reviewed, tested and verified all technical content personally before submitting.

---

Thank you for contributing to the Ubuntu Server documentation!
