### PR TITLE
Add site to linkchecker ignore list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,6 +261,7 @@ linkcheck_ignore = [
     "https://www.openstack.org/*",
     "https://web.archive.org/web/20241130024605/http://networktimesecurity.org/",
     "https://www.intel.com/*",
+    "https://www.packtpub.com/*",
     # Rate-limited domains that cause delays
     "http://www.gnu.org/software/*",
     "https://github.com./*",


### PR DESCRIPTION
### Description

Continuing with the weekly tradition, we've had another site start blocking web bots, which causes them to fail the linkchecker.

The links validly work for humans (I checked), so adding to linkcheck ignore list.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
