### PR TITLE
console-security: document how to disable Magic SysRq keys

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -254,6 +254,7 @@ sudo
 sysctls
 vsock
 syslog
+SysRq
 systemctl
 systemd
 tasksel

--- a/docs/how-to/security/console-security.md
+++ b/docs/how-to/security/console-security.md
@@ -36,8 +36,12 @@ The Linux kernel's [Magic SysRq](https://www.kernel.org/doc/html/latest/admin-gu
 feature allows keyboard shortcuts to send low-level commands directly to the kernel, bypassing
 any running applications and without requiring a login. By default, Ubuntu enables a subset of
 these functions, including the ability to immediately reboot ({kbd}`Alt` + {kbd}`SysRq` +
-{kbd}`b`) or power off ({kbd}`Alt` + {kbd}`SysRq` + {kbd}`o`) the machine. As with
-Ctrl+Alt+Delete, this is worth addressing as part of your physical access hardening.
+{kbd}`b`) or power off ({kbd}`Alt` + {kbd}`SysRq` + {kbd}`o`) the machine. As with {kbd}`Ctrl` +
+{kbd}`Alt` + {kbd}`Delete`, this is worth addressing as part of your physical access hardening.
+
+:::{note}
+On most keyboards, {kbd}`SysRq` is labeled as {kbd}`PrtScn`.
+:::
 
 You can check which functions are currently enabled:
 
@@ -51,7 +55,7 @@ kernel.sysrq = 176
 
 The default value of `176` enables filesystem sync (16), remounting read-only
 (32), and reboot/poweroff (128). To disable all SysRq functions, create an override file in
-`/etc/sysctl.d/` with a higher sort order than the default sysrq configuration file `10-magic-sysrq.conf`:
+`/etc/sysctl.d/` with a higher sort order than the default SysRq configuration file `10-magic-sysrq.conf`:
 
 ```bash
 echo "kernel.sysrq = 0" | sudo tee /etc/sysctl.d/99-disable-sysrq.conf
@@ -60,6 +64,13 @@ sudo sysctl --system
 
 The `99-` prefix ensures this file is processed after `10-magic-sysrq.conf`, and the setting
 persists across reboots.
+
+:::{note}
+A list of all of the available SysRq values and a brief description explaining what
+each value does can be found by examining `/etc/sysctl.d/10-magic-sysrq.conf`.
+
+Beyond that, further explanation can be found by referencing the [SysRq section on the Linux Kernel documentation website](https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html).
+:::
 
 Verify the change has taken effect:
 

--- a/docs/how-to/security/console-security.md
+++ b/docs/how-to/security/console-security.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: Secure your Ubuntu Server console by disabling Ctrl+Alt+Delete reboots and implementing physical access protection measures.
+    description: Secure your Ubuntu Server console by disabling Ctrl+Alt+Delete, Magic SysRq reboots and implementing physical access protection measures.
 ---
 
 (console-security)=
@@ -27,5 +27,55 @@ To re-enable this feature, use:
 
 ```bash
 sudo systemctl unmask ctrl-alt-del.target
+```
+:::
+
+## Disable Magic SysRq keys
+
+The Linux kernel's [Magic SysRq](https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html)
+feature allows keyboard shortcuts to send low-level commands directly to the kernel, bypassing
+any running applications and without requiring a login. By default, Ubuntu enables a subset of
+these functions, including the ability to immediately reboot ({kbd}`Alt` + {kbd}`SysRq` +
+{kbd}`b`) or power off ({kbd}`Alt` + {kbd}`SysRq` + {kbd}`o`) the machine. As with
+Ctrl+Alt+Delete, this is worth addressing as part of your physical access hardening.
+
+You can check which functions are currently enabled:
+
+```bash
+sysctl kernel.sysrq
+```
+
+```text
+kernel.sysrq = 176
+```
+
+The default value of `176` enables filesystem sync (16), remounting read-only
+(32), and reboot/poweroff (128). To disable all SysRq functions, create an override file in
+`/etc/sysctl.d/` with a higher sort order than the default sysrq configuration file `10-magic-sysrq.conf`:
+
+```bash
+echo "kernel.sysrq = 0" | sudo tee /etc/sysctl.d/99-disable-sysrq.conf
+sudo sysctl --system
+```
+
+The `99-` prefix ensures this file is processed after `10-magic-sysrq.conf`, and the setting
+persists across reboots.
+
+Verify the change has taken effect:
+
+```bash
+sysctl kernel.sysrq
+```
+
+```text
+kernel.sysrq = 0
+```
+
+:::{note}
+To re-enable the default SysRq functions, remove the override file and reload:
+
+```bash
+sudo rm /etc/sysctl.d/99-disable-sysrq.conf
+sudo sysctl --system
 ```
 :::


### PR DESCRIPTION
### Description

Adds a new section to the console security page documenting how to disable Magic SysRq keyboard shortcuts. Since the page already covers disabling Ctrl+Alt+Delete to prevent unauthorised reboots, it makes sense to also cover Alt+SysRq+b and Alt+SysRq+o, which are enabled by default (kernel.sysrq = 176) and pose the same physical access risk on a production server.

---

### Related Issue

- Fixes: #538 

---

### Commit Message for Squash Merge

console-security: document how to disable Magic SysRq keys

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes

Tested on Ubuntu Server 24.04. Commands verified to apply immediately via `sysctl --system` and confirmed to persist across reboots.