### PR TITLE
intro-to/web-servers: fix page title and heading hierarchy

### DIFF
--- a/docs/explanation/intro-to/web-servers.md
+++ b/docs/explanation/intro-to/web-servers.md
@@ -1,11 +1,11 @@
 ---
 myst:
   html_meta:
-    description: Introduction to web servers on Ubuntu including Apache2, nginx, and proxy servers for hosting websites and web applications.
+    description: Introduction to web services on Ubuntu including Apache2, nginx, and proxy servers for hosting websites and web applications.
 ---
 
-(introduction-to-web-servers)=
-# Introduction to web servers
+(introduction-to-web-services)=
+# Introduction to web services
 
 Web servers are used to serve web pages requested by client computers. Clients typically request and view web pages using web browser applications such as Firefox, Opera, Chromium, or Internet Explorer.
 
@@ -15,7 +15,7 @@ If you're new to web servers, see this page for more information {ref}`on the ke
 
 Squid is a popular, open-source, proxy caching server that can help optimize network efficiency and improve response times by saving local copies of frequently accessed content. Read more {ref}`about Squid proxy servers <about-squid-proxy-servers>` and what they can do, or find out {ref}`how to install a Squid server <install-a-squid-server>`.
 
-### Web server
+## Web servers
 
 Apache is a widely used web server on Linux systems, and the current version is Apache2. It is robust, reliable, and highly configurable. This set of guides will show you:
 
@@ -29,11 +29,11 @@ Nginx is a popular alternative web server also widely used on Linux, with a focu
 - {ref}`How to configure Nginx <configure-nginx>`
 - {ref}`How to use Nginx modules <use-nginx-modules>`
 
-### Database server
+## Database server
 
 The database server, when included in the LAMP stack (Linux + Apache + MySQL + PHP/Perl/Python), allows data for web applications to be stored and managed. MySQL is one of the most popular open source Relational Database Management Systems (RDBMS) available, and you can find out in this guide {ref}`how to install MySQL <install-mysql>` -- or {ref}`PostgreSQL <install-postgresql>`, as another popular alternative.
 
-### Scripting languages
+## Scripting languages
 
 Server-side scripting languages allow for the creation of dynamic web content, processing of web forms, and interacting with databases (amongst other crucial tasks). PHP is often used, and we can show you {ref}`how to install PHP <install-php>`, or if you prefer, we can show you {ref}`how to install Ruby on Rails <install-ruby-on-rails>`.
 

--- a/docs/how-to/observability/install-munin.md
+++ b/docs/how-to/observability/install-munin.md
@@ -15,7 +15,7 @@ In this example, we will use two servers with {term}`hostnames <hostname>`: **`s
 
 ## Prerequisites
 
-Before installing Munin on `server01`, {ref}`Apache2 will need to be installed <introduction-to-web-servers>`. The default configuration is fine for running a `munin` server.
+Before installing Munin on `server01`, {ref}`Apache2 will need to be installed <introduction-to-web-services>`. The default configuration is fine for running a `munin` server.
 
 ## Install `munin` and `munin-node`
 

--- a/docs/how-to/observability/install-nagios.md
+++ b/docs/how-to/observability/install-nagios.md
@@ -66,7 +66,7 @@ There are a couple of directories containing Nagios configuration and check file
 There are multiple checks Nagios can be configured to execute for any given host. For this example, Nagios will be configured to check disk space, {term}`DNS`, and a MySQL {term}`hostgroup`. The DNS check will be on `server02`, and the MySQL hostgroup will include both `server01` and `server02`.
 
 ```{note}
-See these guides for details on {ref}`setting up Apache <introduction-to-web-servers>`, {ref}`Domain Name Service <install-dns>`, and {ref}`MySQL <install-mysql>`.
+See these guides for details on {ref}`setting up Apache <introduction-to-web-services>`, {ref}`Domain Name Service <install-dns>`, and {ref}`MySQL <install-mysql>`.
 ```
 
 Additionally, there are some terms that once explained will hopefully make understanding Nagios configuration easier:

--- a/docs/how-to/web-services.md
+++ b/docs/how-to/web-services.md
@@ -7,7 +7,7 @@ myst:
 (how-to-web-services)=
 # Web services
 
-Web servers are used to serve content over a network (or the Internet). If you want more of an introduction to the different types of web servers available in Ubuntu, check out our {ref}`introduction-to-web-servers`.
+Web servers are used to serve content over a network (or the Internet). If you want more of an introduction to the different types of web servers available in Ubuntu, check out our {ref}`introduction-to-web-services`.
 
 ## Proxy servers
 


### PR DESCRIPTION
### Description

Fixes two issues at https://documentation.ubuntu.com/server/explanation/intro-to/web-servers/:

- The page title and anchor have been updated from "web servers" to "web services", consistent with how the page is labelled in the navigation.
- The internal heading hierarchy has been corrected: `Web servers`, `Database server`, and `Scripting languages` were at h3 level while `Squid proxy server` was at h2. All four sections are now h2.

Cross-references to the renamed anchor in `how-to/web-services.md`, `install-nagios.md`, and `install-munin.md` have been updated accordingly.

Note: the filename (`web-servers.md`) and its corresponding URL have been left unchanged to avoid breaking external links. This could be addressed as a follow-up if desired.

---

### Related Issue

- Fixes: #514 

---

### Commit Message for Squash Merge

intro-to/web-servers: fix page title and heading hierarchy

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Tested locally with `make html`. Used LLM to ensure I didn't miss any of the references.