### PR TITLE
Update manpage URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,7 +295,7 @@ stable_distro = "resolute"
 manpages_url = (
     "https://manpages.ubuntu.com/manpages/"
     + stable_distro
-    + "/en/man{section}/{page}.{section}.html"
+    + "/man{section}/{page}.{section}.html"
 )
 
 


### PR DESCRIPTION
### Description

As [reported by Robert](https://github.com/ubuntu/ubuntu-project-docs/issues/556) in the Project docs, the manpage URLs were changed to remove language support. This means we need to change our auto-generating manpage link configuration to take this into account.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

