### PR TITLE
Fix failing linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -262,7 +262,7 @@ linkcheck_ignore = [
     "https://web.archive.org/web/20241130024605/http://networktimesecurity.org/",
     "https://www.intel.com/*",
     "https://www.packtpub.com/*",
-    # Rate-limited domains that cause delays
+    "https://www.redbooks.ibm.com/*",
     "http://www.gnu.org/software/*",
     "https://github.com./*",
 ]


### PR DESCRIPTION
### Description

The IBM Redbooks page works, but refuses bots so it's reported as broken in the linkchecker.
This PR adds it to the ignore list.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
