### PR TITLE
Replace icons with text in table

### DIFF
--- a/docs/explanation/active-directory/choosing-an-integration-method.md
+++ b/docs/explanation/active-directory/choosing-an-integration-method.md
@@ -14,16 +14,16 @@ Three main criteria need to be evaluated:
 * member server or workstation: Is the Ubuntu system that is being joined to Active Directory going to be a member server (it provides authentication and shares), or just a workstation/desktop which will not share files via the SMB protocol? If a workstation is also going to share files via SMB, then consider it a member server.
 * Deterministic Linux ID: is it important that the same Active Directory user obtains the same Linux ID on all joined systems? For example, if NFS exports will be used between the joined systems.
 
-|Requirement / Method      |SSSD |idmap\_rid  |idmap\_autorid|
-|------------------------- |:--: |:----------:|:------------:|
-| Deterministic ID         | ✅ |    ✅      |      ❌      |
-| Undetermined  ID         | ✅ |    ✅      |      ✅      |
-| Member server            | ❌ |    ✅      |      ✅      |
-| Not a member server      | ✅ |    ✅      |      ✅      |
-| AD multi-domain (forest) | ❌ |    ❌(\*)  |      ✅      |
-| AD single domain         | ✅ |    ✅      |      ✅      |
+| Requirement/Method       | SSSD | `idmap_rid` | `idmap_autorid` |
+|--------------------------|:----:|:-----------:|:---------------:|
+| Deterministic ID         | Y    |    Y        |      N          |
+| Undetermined  ID         | Y    |    Y        |      Y          |
+| Member server            | N    |    Y        |      Y          |
+| Not a member server      | Y    |    Y        |      Y          |
+| AD multi-domain (forest) | N    |    N(\*)    |      Y          |
+| AD single domain         | Y    |    Y        |      Y          |
 
-(\*) The *idmap_rid* choice for multi-domain Active Directory is doable, but with important caveats that are better explained in {ref}`Joining a forest with the rid backend <join-a-forest-with-the-rid-backend>`.
+(\*) The *`idmap_rid`* choice for multi-domain Active Directory is doable, but with important caveats that are better explained in {ref}`Joining a forest with the rid backend <join-a-forest-with-the-rid-backend>`.
 
 Before going into the details of each integration method, it's a good idea to familiarise yourself with the other basic concepts of Active Directory integration. These are shown next:
 


### PR DESCRIPTION
### Description


As reported in #700, the table is not rendering correctly in the PDF due to a lack of encoding for those symbols. This PR replaces the emoji symbols with plain text.

---

### Related Issue

- Fixes: #700 

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

