### PR TITLE
Tweaks to the snapshot service howto

### DIFF
--- a/docs/how-to/software/snapshot-service.md
+++ b/docs/how-to/software/snapshot-service.md
@@ -59,16 +59,14 @@ command line options in Ubuntu releases lower than 24.04.
 
 The following table describes whether the snapshot service can be used with
 each supported Ubuntu release, and whether or not it is necessary to configure
-the `snapshot` option in the `sources.list` file.
+the `snapshot` option in your sources configuration.
 
-| Ubuntu Release       | Supports Snapshot Service?   | Need to configure `sources.list`? |
-|----------------------|------------------------------|-----------------------------------|
-| Next Ubuntu releases | Yes                          | No                                |
-| Ubuntu 25.10         | Yes                          | No                                |
-| Ubuntu 25.04         | Yes                          | No                                |
-| Ubuntu 24.04 LTS     | Yes                          | No                                |
-| Ubuntu 22.04 LTS     | Yes (with `apt` >= `2.4.11`) | Yes                               |
-| Ubuntu 20.04 LTS     | Yes (with `apt` >= `2.0.10`) | Yes                               |
+| Ubuntu Release       | Supports Snapshot Service?   | Need to configure sources? |
+|----------------------|------------------------------|----------------------------|
+| Next Ubuntu releases | Yes                          | No                         |
+| Ubuntu 24.04 LTS     | Yes                          | No                         |
+| Ubuntu 22.04 LTS     | Yes (with `apt` >= `2.4.11`) | Yes                        |
+| Ubuntu 20.04 LTS     | Yes (with `apt` >= `2.0.10`) | Yes                        |
 
 ## Quick start
 
@@ -194,23 +192,15 @@ package.
 ### Configuring the snapshot service for specific repositories
 
 In your `apt` repositories configuration files, it is possible to specify
-snapshots to be used for each specific repository.
-
-For Ubuntu 24.04 LTS and later, which uses the deb822 style by default, we add
-a `Snapshot` option to the relevant sources file in the following format:
+snapshots to be used for each specific repository. In the deb822 format, add a
+`Snapshot` option to the relevant stanza in your `.sources` file:
 
 ```
 Snapshot: $SNAPSHOT_ID
 ```
 
-For Ubuntu series lower than 24.04, you change the value of the `snapshot`
-option in your sources file, i.e., if you had the following entry in your `/etc/apt/sources.list` file
-
-```
-deb [snapshot=yes] http://archive.ubuntu.com/ubuntu ...
-```
-
-you replace the `yes` value with the snapshot ID:
+If you are using the one-line format in `/etc/apt/sources.list` (Ubuntu 22.04
+and earlier), replace the `yes` value with the snapshot ID:
 
 ```
 deb [snapshot=$SNAPSHOT_ID] http://archive.ubuntu.com/ubuntu ...


### PR DESCRIPTION
### Description
Consider deb822 as the expected format, and old .list files as the non-standard for the configuration.

Issue #641 asks for deb822 as the default format for this guide, but after reviewing I consider the use of each format is right. `.list` files are mentioned for releases <=22.04, where they should be mentioned. This is a slight reword to make clear the deb822 is the expected, and `.list` the exception.

---

### Related Issue

- Fixes: #641

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

Thank you for contributing to the Ubuntu Server documentation!

you welcome