### PR TITLE
Create page on how to obtain TLS certificates

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -29,6 +29,7 @@ Byobu
 Canonical's
 CAs
 CDBs
+Certbot
 checksumming
 Chrony
 chroot
@@ -130,6 +131,7 @@ Keytab
 keytab
 keytool
 LANs
+lego
 lightervisor
 livepatching
 LLMs
@@ -307,6 +309,7 @@ vsftpd
 vSwitch
 WANs
 webpages
+webroot
 winbind
 WWIDs
 www

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -39,6 +39,7 @@ DNSSEC <dnssec/dnssec>
 
 * {ref}`Our cryptography section <explanation-cryptography>` explains in detail about the different cryptographic libraries and configurations you might encounter.
 * {ref}`Certificates <certificates>` are issued, stored and signed by a Certificate Authority (CA) to create trusted connections.
+* {ref}`How to obtain certificates <obtain-tls-certificates>` is a step-by-step guide covering Let's Encrypt (via Certbot) and local CA implementation.
 
 ```{toctree}
 :hidden:

--- a/docs/explanation/security/certificates.md
+++ b/docs/explanation/security/certificates.md
@@ -114,64 +114,9 @@ Now configure any applications that have the ability to use public-key cryptogra
 
 ## Certification Authority
 
-If the services on your network require more than a few self-signed certificates it may be worth the additional effort to setup your own internal Certification Authority (CA). Using certificates signed by your own CA allows the various services using the certificates to easily trust other services using certificates issued from the same CA.
+If the services on your network require more than a few self-signed certificates it may be worth the additional effort to set up your own internal Certification Authority (CA). Using certificates signed by your own CA allows the various services using the certificates to easily trust other services using certificates issued from the same CA.
 
-First, create the directories to hold the CA certificate and related files:
-
-```bash
-sudo mkdir /etc/ssl/CA
-sudo mkdir /etc/ssl/newcerts
-```
-
-The CA needs a few additional files to operate; one to keep track of the last serial number used by the CA (each certificate must have a unique serial number), and another file to record which certificates have been issued:
-
-```bash
-sudo sh -c "echo '01' > /etc/ssl/CA/serial"
-sudo touch /etc/ssl/CA/index.txt
-```
-
-The third file is a CA configuration file. Though not strictly necessary, it is convenient when issuing multiple certificates. Edit `/etc/ssl/openssl.cnf`, and in the `[ CA_default ]`, change:
-
-```text
-dir             = /etc/ssl              # Where everything is kept
-database        = $dir/CA/index.txt     # database index file.
-certificate     = $dir/certs/cacert.pem # The CA certificate
-serial          = $dir/CA/serial        # The current serial number
-private_key     = $dir/private/cakey.pem# The private key
-```
-
-Next, create the self-signed root certificate:
-
-```bash
-openssl req -new -x509 -extensions v3_ca -keyout cakey.pem -out cacert.pem -days 3650
-```
-
-You will then be asked to enter the details about the certificate. Next, install the root certificate and key:
-
-```bash
-sudo mv cakey.pem /etc/ssl/private/
-sudo mv cacert.pem /etc/ssl/certs/
-```
-
-You are now ready to start signing certificates. The first item needed is a Certificate Signing Request (CSR) -- see the "Generating a CSR" section above for details. Once you have a CSR, enter the following to generate a certificate signed by the CA:
-
-```bash
-sudo openssl ca -in server.csr -config /etc/ssl/openssl.cnf
-```
-
-After entering the password for the CA key, you will be prompted to sign the certificate, and again to commit the new certificate. You should then see a somewhat large amount of output related to the certificate creation.
-
-There should now be a new file, `/etc/ssl/newcerts/01.pem`, containing the same output. Copy and paste everything beginning with the `-----BEGIN CERTIFICATE-----` line and continuing through to the `----END CERTIFICATE-----` lines to a file named after the {term}`hostname` of the server where the certificate will be installed. For example `mail.example.com.crt`, is a nice descriptive name.
-
-Subsequent certificates will be named `02.pem`, `03.pem`, etc.
-
-```{note}
-Replace `mail.example.com.crt` with your own descriptive name.
-```
-
-Finally, copy the new certificate to the host that needs it, and configure the appropriate applications to use it. The default location to install certificates is `/etc/ssl/certs`. This enables multiple services to use the same certificate without overly complicated file permissions.
-
-For applications that can be configured to use a CA certificate, you should also copy the `/etc/ssl/certs/cacert.pem` file to the `/etc/ssl/certs/` directory on each server.
+Creating and running your own CA is covered step by step in {ref}`obtain-tls-certificates`.
 
 ## Further reading
 

--- a/docs/how-to/databases/install-postgresql.md
+++ b/docs/how-to/databases/install-postgresql.md
@@ -60,7 +60,7 @@ hostssl template1       postgres        192.168.1.1/24        scram-sha-256
 ```
 
 ```{note}
-The config statement `hostssl` used here will reject TCP connections that would not use SSL. PostgreSQL in Ubuntu has the SSL feature built in and configured by default, so it works right away. On your PostgreSQL server this uses the certificate created by `ssl-cert` package which is great, but for production use you should consider updating that with a proper certificate from a recognized Certificate Authority (CA).
+The config statement `hostssl` used here will reject TCP connections that would not use SSL. PostgreSQL in Ubuntu has the SSL feature built in and configured by default, so it works right away. On your PostgreSQL server this uses the certificate created by the `ssl-cert` package which is suitable for testing, but for production use you should replace it with a certificate from a trusted Certificate Authority (CA). See {ref}`obtain-tls-certificates` for how to get a certificate from Let's Encrypt or set up your own CA.
 ```
 
 Finally, you should restart the PostgreSQL service to initialize the new configuration. From a terminal prompt enter the following to restart PostgreSQL:

--- a/docs/how-to/mail-services/install-dovecot.md
+++ b/docs/how-to/mail-services/install-dovecot.md
@@ -67,10 +67,10 @@ ssl_cert = </etc/dovecot/private/dovecot.pem
 ssl_key = </etc/dovecot/private/dovecot.key
 ```
 
-You can get the SSL certificate from a Certificate Issuing Authority or you can create self-signed one. Once you create the certificate, you will have a key file and a certificate file that you want to make known in the config shown above.
+You can obtain an SSL certificate from Let's Encrypt, from a commercial Certificate Authority (CA), or create a self-signed one. Once you have the certificate, you will have a key file and a certificate file to reference in the configuration above.
 
 ```{seealso}
-For more details on creating custom certificates, see our guide on {ref}`security certificates <certificates>`.
+See {ref}`obtain-tls-certificates` for how to get a trusted certificate or set up your own CA.
 ```
 
 ## Configure a firewall for an email server

--- a/docs/how-to/mail-services/install-exim4.md
+++ b/docs/how-to/mail-services/install-exim4.md
@@ -97,7 +97,7 @@ sudo /usr/share/doc/exim4-base/examples/exim-gencert
 This command will ask some questions about the certificate, like country, city, and others. The most important one, and that must be correct otherwise TLS won't work for this server, is the "Server name" one. It **MUST** match the fully qualified hostname (FQDN) of the system where Exim4 is deployed.
 
 ```{warning}
-This will install a self-signed certificate. If deploying this system in production, you must get a proper certificate signed by a recognized Certificate Authority (CA), or, if using an internal, you will have to distribute the CA to all clients expected to connect to this server.
+This will install a self-signed certificate. If deploying this system in production, obtain a trusted certificate instead. See {ref}`obtain-tls-certificates` for how to get a certificate, or how to set up your own Certificate Authority (CA) for internal deployments.
 ```
 Configure Exim4 for TLS by editing the `/etc/exim4/conf.d/main/03_exim4-config_tlsoptions` file and adding the following:
 

--- a/docs/how-to/mail-services/install-postfix.md
+++ b/docs/how-to/mail-services/install-postfix.md
@@ -91,9 +91,9 @@ There are several SASL mechanism properties worth evaluating to improve the secu
 
 ### Configure TLS
 
-Next, generate or obtain a digital certificate for TLS. MUAs connecting to your mail server via TLS will need to recognize the certificate used for TLS. This can either be done using a certificate from Let's Encrypt, from a commercial CA or with a self-signed certificate that users manually install/accept.
+Next, generate or obtain a digital certificate for TLS. MUAs connecting to your mail server via TLS will need to recognize the certificate used for TLS. This can be done using a certificate from Let's Encrypt, from a commercial CA, or with a self-signed certificate that users manually install and accept.
 
-For MTA-to-MTA, TLS certificates are never validated without prior agreement from the affected organizations. For MTA-to-MTA TLS, there is no reason not to use a self-signed certificate unless local policy requires it. See our {ref}`guide on security certificates <certificates>` for details about generating digital certificates and setting up your own Certificate Authority (CA).
+For MTA-to-MTA, TLS certificates are never validated without prior agreement from the affected organizations. For MTA-to-MTA TLS, there is no reason not to use a self-signed certificate unless local policy requires it. See {ref}`obtain-tls-certificates` for how to set up your own Certificate Authority (CA).
 
 Once you have a certificate, configure Postfix to provide TLS encryption for both incoming and outgoing mail:
 
@@ -113,7 +113,7 @@ If you are using your own Certificate Authority to sign the certificate, enter:
 sudo postconf -e 'smtpd_tls_CAfile = /etc/ssl/certs/cacert.pem'
 ```
 
-Again, for more details about certificates see our {ref}`security certificates guide <certificates>`.
+Again, for more details about certificates see {ref}`obtain-tls-certificates`.
 
 ### Outcome of initial configuration
 

--- a/docs/how-to/openldap/ldap-and-tls.md
+++ b/docs/how-to/openldap/ldap-and-tls.md
@@ -10,7 +10,7 @@ myst:
 
 When authenticating to an OpenLDAP server it is best to do so using an encrypted session. This can be accomplished using Transport Layer Security (TLS).
 
-Here, we will be our own Certificate Authority (CA) and then create and sign our LDAP server certificate as that CA. This guide will use the `certtool` utility to complete these tasks. For simplicity, this is being done on the OpenLDAP server itself, but your real internal CA should be elsewhere.
+Here, we will act as our own Certificate Authority (CA) and create and sign the LDAP server certificate as that CA. This guide will use the `certtool` utility to complete these tasks. For simplicity, this is being done on the OpenLDAP server itself, but your real internal CA should be elsewhere.
 
 Install the `gnutls-bin` and `ssl-cert` packages:
 

--- a/docs/how-to/security.md
+++ b/docs/how-to/security.md
@@ -47,10 +47,13 @@ Smart cards <security/smart-card-authentication>
 
 The Secure Shell (SSH) cryptographic protocol that provides secure channels on an unsecured network. In Ubuntu, OpenSSH is the most commonly used implementation of SSH. It provides a suite of utilities for encrypting data transfers and can also be used for remote login and authentication.
 
+* {ref}`Obtain TLS certificates <obtain-tls-certificates>` covers both Let's Encrypt (for internet-facing servers) and running your own Certificate Authority (CA) for internal networks
+
 ```{toctree}
 :titlesonly:
 
 OpenSSH <security/openssh-server>
+Obtain TLS certificates <security/obtain-tls-certificates>
 Install a root CA certificate <security/install-a-root-ca-certificate-in-the-trust-store>
 ```
 

--- a/docs/how-to/security/install-openvpn.md
+++ b/docs/how-to/security/install-openvpn.md
@@ -35,6 +35,8 @@ Both the server and the client will authenticate each other by first verifying t
 
 ### Set up the Certificate Authority
 
+OpenVPN uses its own internal Public Key Infrastructure (PKI) where every client and server holds a certificate signed by the same CA. This is different from obtaining a public TLS certificate for a web service; the CA here is private and only used to authenticate VPN participants.
+
 To set up your own CA, and generate certificates and keys for an OpenVPN server with multiple clients, first copy the `easy-rsa` directory to `/etc/openvpn`. This will ensure that any changes to the scripts will not be lost when the package is updated. From a terminal, run:
 
 ```bash

--- a/docs/how-to/security/obtain-tls-certificates.md
+++ b/docs/how-to/security/obtain-tls-certificates.md
@@ -1,0 +1,254 @@
+---
+myst:
+  html_meta:
+    description: "Obtain trusted TLS certificates with Let's Encrypt and Certbot on Ubuntu, or set up your own Certificate Authority for internal networks."
+---
+
+(obtain-tls-certificates)=
+# Obtain TLS certificates
+
+Transport Layer Security (TLS) certificates authenticate your server's identity and enable encrypted connections. There are two main approaches:
+
+- **Let's Encrypt** (recommended for internet-facing servers): a free, automated Certificate Authority (CA) whose certificates are trusted by all major browsers and clients.
+- **Manual CA** (for internal networks or air-gapped environments): run your own CA and sign certificates yourself; requires distributing the CA certificate to all clients.
+
+## Use Let's Encrypt
+
+[Let's Encrypt](https://letsencrypt.org/) is operated by the Internet Security Research Group (ISRG). It issues certificates via the Automated Certificate Management Environment (ACME) protocol. Certificates are valid for 90 days and can be renewed automatically.
+
+### Prerequisites
+
+- A registered domain name with DNS records pointing to the server.
+- Port 80 open in your firewall. The default [HTTP-01 challenge](https://letsencrypt.org/docs/challenge-types/#http-01-challenge) verifies domain ownership by making an HTTP request to your server on port 80, so it must be reachable from the internet during certificate issuance and renewal.
+
+### Install Certbot
+
+[Certbot](https://certbot.eff.org/) is the recommended ACME client for Let's Encrypt. Install it from the snap store:
+
+```bash
+sudo snap install --classic certbot
+```
+
+### Obtain a certificate
+
+Certbot supports several modes depending on whether a web server is already running.
+
+**With an nginx server running:**
+
+Certbot's [nginx plugin](https://certbot.eff.org/docs/using.html#nginx) finds the server block matching the specified domains in your nginx configuration (typically in `/etc/nginx/sites-enabled/`) and adds the necessary TLS directives in place, then reloads nginx:
+
+```bash
+sudo certbot --nginx -d example.com -d www.example.com
+```
+
+**With an Apache server running:**
+
+Certbot's [Apache plugin](https://certbot.eff.org/docs/using.html#apache) finds the VirtualHost block matching the specified domains in your Apache configuration (typically in `/etc/apache2/sites-enabled/`) and adds the necessary TLS directives in place, then reloads Apache:
+
+```bash
+sudo certbot --apache -d example.com -d www.example.com
+```
+
+**Without a web server (standalone mode):**
+
+Certbot starts a temporary web server on port 80 to complete the ACME challenge. Stop any service already listening on port 80 before running this.
+
+```bash
+sudo certbot certonly --standalone -d example.com -d www.example.com
+```
+
+**With a web server managing the document root (webroot mode):**
+
+If you want to obtain a certificate without modifying your web server configuration, specify the directory the web server serves:
+
+```bash
+sudo certbot certonly --webroot -w /var/www/html -d example.com
+```
+
+**Multiple domains:**
+
+Each `-d` flag adds a domain as a Subject Alternative Name (SAN), so a single certificate can cover multiple domains and subdomains. If a certificate for any of the listed domains already exists, Certbot expands it to include all specified domains. Pass the complete desired domain list — both existing and new — in a single command:
+
+```bash
+sudo certbot --nginx -d example.com -d www.example.com -d mail.example.com
+```
+
+### Other challenge methods
+
+The modes above all use the [HTTP-01 challenge](https://letsencrypt.org/docs/challenge-types/#http-01-challenge) and require port 80. For servers not reachable on port 80, or when you need wildcard certificates (e.g., `*.example.com`), you can use the [DNS-01 challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) instead: it verifies domain ownership via a DNS TXT record and has no inbound port requirements. Certbot supports DNS-01 via [DNS plugins](https://certbot.eff.org/docs/using.html#dns-plugins) for common providers (Cloudflare, Route 53, etc.).
+
+For environments where running an ACME client on each server is not practical — such as air-gapped networks or large fleets — an [ACME proxy server](https://smallstep.com/docs/step-ca/) (such as step-ca) can act as an internal CA that forwards requests to Let's Encrypt, or a centralised ACME client such as [acme.sh](https://acme.sh) or [lego](https://go-acme.github.io/lego/) can manage certificate issuance and distribution centrally.
+
+### Locate the issued certificate files
+
+After a successful run, Certbot writes the certificate files to `/etc/letsencrypt/live/<domain>/`:
+
+| File | Contents |
+|------|----------|
+| `fullchain.pem` | Server certificate plus any intermediate certificates (use this in most service configurations) |
+| `privkey.pem` | Private key |
+| `cert.pem` | Server certificate only |
+| `chain.pem` | Intermediate certificates only |
+
+Point your service configuration at the files in this directory. For example in nginx:
+
+```text
+ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+```
+
+### Automatic renewal
+
+Certbot installs a systemd timer that attempts renewal twice a day. Check that it is active:
+
+```bash
+sudo systemctl status snap.certbot.renew.timer
+```
+
+Test the renewal process without making any changes:
+
+```bash
+sudo certbot renew --dry-run
+```
+
+Services configured using the Certbot nginx or Apache plugins are reloaded automatically after a successful renewal. For other services, add a renewal hook. Create `/etc/letsencrypt/renewal-hooks/deploy/reload-service.sh`:
+
+```bash
+#!/bin/sh
+systemctl reload <your-service>
+```
+
+Then make it executable:
+
+```bash
+sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-service.sh
+```
+
+Replace `<your-service>` with the name of the service to reload after renewal (e.g., `postfix`, `dovecot`, `slapd`).
+
+## Set up a manual Certificate Authority
+
+If the services on your network require more than a few self-signed certificates it may be worth the additional effort to set up your own internal Certification Authority (CA). Using certificates signed by your own CA allows the various services using the certificates to easily trust other services using certificates issued from the same CA.
+
+```{note}
+Clients that connect to your services must trust your CA. You will need to install your CA certificate in the trust store of every client, or distribute it to users. See {ref}`install-a-root-ca-certificate-in-the-trust-store` for how to add a CA certificate to Ubuntu's trust store.
+```
+
+### Create the CA directory structure
+
+First, create the directories to hold the CA certificate and related files:
+
+```bash
+sudo mkdir /etc/ssl/CA
+sudo mkdir /etc/ssl/newcerts
+```
+
+The CA needs a few additional files to operate: one to keep track of the last serial number used by the CA (each certificate must have a unique serial number), and another file to record which certificates have been issued:
+
+```bash
+sudo sh -c "echo '01' > /etc/ssl/CA/serial"
+sudo touch /etc/ssl/CA/index.txt
+```
+
+### Configure OpenSSL
+
+The third file needed is a CA configuration file. Though not strictly necessary, it is convenient when issuing multiple certificates. Edit `/etc/ssl/openssl.cnf`, and in the `[ CA_default ]` section, change:
+
+```text
+dir             = /etc/ssl               # Where everything is kept
+database        = $dir/CA/index.txt      # database index file.
+certificate     = $dir/certs/cacert.pem  # The CA certificate
+serial          = $dir/CA/serial         # The current serial number
+private_key     = $dir/private/cakey.pem # The private key
+```
+
+### Create the self-signed root certificate
+
+```bash
+openssl req -new -x509 -extensions v3_ca -keyout cakey.pem -out cacert.pem -days 3650
+```
+
+You will then be asked to enter the details about the certificate. Next, install the root certificate and key:
+
+```bash
+sudo mv cakey.pem /etc/ssl/private/
+sudo mv cacert.pem /etc/ssl/certs/
+```
+
+### Generate a Certificate Signing Request (CSR)
+
+You are now ready to start signing certificates. The first item needed is a Certificate Signing Request (CSR). If the certificate will be used by service daemons, such as Apache, Postfix, Dovecot, etc., a key without a passphrase is often appropriate. Not having a passphrase allows the services to start without manual intervention, usually the preferred way to start a daemon.
+
+```{warning}
+Running your secure service without a passphrase is convenient but insecure -- a compromise of the key means a compromise of the server as well.
+```
+
+To generate the keys for the Certificate Signing Request (CSR) run the following command from a terminal prompt:
+
+```bash
+openssl genrsa -des3 -out server.key 2048
+
+Generating RSA private key, 2048 bit long modulus
+..........................++++++
+.......++++++
+e is 65537 (0x10001)
+Enter pass phrase for server.key:
+```
+
+You can now enter your passphrase. For best security, it should contain **at least** eight characters. The minimum length when specifying `-des3` is four characters. As a best practice it should also include numbers and/or punctuation and not be a word in a dictionary. Also remember that your passphrase is case-sensitive.
+
+Re-type the passphrase to verify. Once you have re-typed it correctly, the server key is generated and stored in the `server.key` file.
+
+Now create the insecure key, the one without a passphrase, and shuffle the key names:
+
+```bash
+openssl rsa -in server.key -out server.key.insecure
+mv server.key server.key.secure
+mv server.key.insecure server.key
+```
+
+The insecure key is now named `server.key`, and you can use this file to generate the CSR without a passphrase.
+
+To create the CSR, run the following command at a terminal prompt:
+
+```bash
+openssl req -new -key server.key -out server.csr
+```
+
+It will prompt you to enter the passphrase. If you enter the correct passphrase, it will prompt you to enter 'Company Name', 'Site Name', 'Email ID', etc. Once you enter all these details, your CSR will be created and it will be stored in the `server.csr` file.
+
+### Sign the certificate
+
+Enter the following to generate a certificate signed by the CA:
+
+```bash
+sudo openssl ca -in server.csr -config /etc/ssl/openssl.cnf
+```
+
+After entering the password for the CA key, you will be prompted to sign the certificate, and again to commit the new certificate. You should then see a somewhat large amount of output related to the certificate creation.
+
+There should now be a new file, `/etc/ssl/newcerts/01.pem`, containing the same output. Copy and paste everything beginning with the `-----BEGIN CERTIFICATE-----` line and continuing through to the `----END CERTIFICATE-----` lines to a file named after the {term}`hostname` of the server where the certificate will be installed. For example `mail.example.com.crt` is a descriptive name.
+
+Subsequent certificates will be named `02.pem`, `03.pem`, etc.
+
+```{note}
+Replace `mail.example.com.crt` with your own descriptive name.
+```
+
+### Install the certificate
+
+Copy the new certificate to the host that needs it, and configure the appropriate applications to use it. The default location to install certificates is `/etc/ssl/certs`. This enables multiple services to use the same certificate without overly complicated file permissions.
+
+```bash
+sudo cp server.key /etc/ssl/private/
+sudo cp mail.example.com.crt /etc/ssl/certs/
+```
+
+For applications that can be configured to use a CA certificate, you should also copy the `/etc/ssl/certs/cacert.pem` file to the `/etc/ssl/certs/` directory on each server that needs to trust certificates issued by your CA.
+
+## Further reading
+
+- [Let's Encrypt documentation](https://letsencrypt.org/docs/)
+- [Certbot documentation](https://certbot.eff.org/docs/)
+- The Wikipedia article on [Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security) provides background on TLS and its history.
+- {ref}`certificates` explains the concepts behind public-key cryptography and certificate types.

--- a/docs/how-to/web-services/configure-nginx.md
+++ b/docs/how-to/web-services/configure-nginx.md
@@ -122,17 +122,7 @@ server {
 
 Thanks to the `return 301` line in the above configuration, anyone visiting the site on port 80 via an HTTP URL will get automatically redirected to the equivalent secure HTTPS URL.
 
-Refer to the {ref}`security - certificates <certificates>` page in this manual for details on how to create and manage certificates, and the {ref}`OpenSSL <openssl>` page for additional details on configuring and using that service. The {ref}`GnuTLS <gnutls>` section explains how to configure different SSL protocol versions and their associated ciphers.
-
-For example, to generate a self-signed certificate, you might run a set of commands similar to these:
-
-```bash
-$ sudo openssl genrsa -out our-site.org.key 2048                                                                   
-$ openssl req -nodes -new -key our-site.org.key -out ca.csr                                                        
-$ openssl x509 -req -days 365 -in our-site.org.csr -signkey our-site.org.key -out our-site.org.crt                 
-$ mkdir /etc/apache2/ssl                                                                                           
-$ cp our-site.org.crt our-site.org.key our-site.org.csr /etc/apache2/ssl/
-```
+Refer to {ref}`obtain-tls-certificates` for how to obtain a trusted certificate from Let's Encrypt (recommended for internet-facing servers) or to set up your own Certificate Authority (CA). The {ref}`OpenSSL <openssl>` page has additional details on configuring and using that service. The {ref}`GnuTLS <gnutls>` section explains how to configure different SSL protocol versions and their associated ciphers.
 
 ## Setting up nginx
 


### PR DESCRIPTION
### Description

This includes using certbot + Let's Encrypt plus the existing information on how to set up a local CA.
This fills gaps and brings information together in the howtos.
Update the references to point to this page.

---

### Related Issue

Fixes: #603

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Disclaimer: After coming up with an outline of the changes, Claude Sonnet was tasked to reword and review all text here - so this is technically AI generated.
Our Copilot friend will have a second look here in the PR.

---

Thank you for contributing to the Ubuntu Server documentation!

you welcome