### PR TITLE
openldap: add guide for simple ldap client using nslcd

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -174,6 +174,7 @@ Munin
 nameserver
 nameservers
 namespace
+nslcd
 NATed
 netboot
 netbooting

--- a/docs/how-to/openldap.md
+++ b/docs/how-to/openldap.md
@@ -22,6 +22,7 @@ OpenLDAP and TLS <openldap/ldap-and-tls>
 Backup and restore <openldap/backup-and-restore>
 Introduction to passthrough authentication <openldap/ldap-saslauthd-authentication-intro>
 Passthrough authentication with Kerberos <openldap/ldap-saslauthd-kerberos>
+Set up an LDAP client <openldap/ldap-client>
 ```
 
 ## See also

--- a/docs/how-to/openldap/access-control.md
+++ b/docs/how-to/openldap/access-control.md
@@ -1,12 +1,11 @@
 ---
 myst:
   html_meta:
-    description: Configure OpenLDAP access control lists (ACLs) to manage read, write, and authentication permissions for LDAP resources.
+    description: Configure OpenLDAP access control lists (ACLs) to manage read, write, and authentication permissions.
 ---
 
 (ldap-access-control)=
 # Set up LDAP access control
-
 
 The management of what type of access (read, write, etc) users should be granted for resources is known as **access control**. The configuration directives involved are called **access control lists** or {term}`ACL`s.
 
@@ -16,20 +15,32 @@ To get the effective ACL for an LDAP query we need to look at the ACL entries of
 
 ## Getting the ACLs
 
-The following commands will give, respectively, the ACLs of the `mdb` database (`dc=example,dc=com`) and those of the frontend database:
+The following commands give the ACLs of the `mdb` database (`dc=example,dc=com`) and those of the frontend database respectively.
+
+For the main database:
 
 ```bash
-$ sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b \
-cn=config '(olcDatabase={1}mdb)' olcAccess
-    
+sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=config '(olcDatabase={1}mdb)' olcAccess
+```
+
+Output:
+
+```text
 dn: olcDatabase={1}mdb,cn=config
 olcAccess: {0}to attrs=userPassword by self write by anonymous auth by * none
 olcAccess: {1}to attrs=shadowLastChange by self write by * read
 olcAccess: {2}to * by * read
+```
 
-$ sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b \
-cn=config '(olcDatabase={-1}frontend)' olcAccess
-    
+For the frontend database:
+
+```bash
+sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=config '(olcDatabase={-1}frontend)' olcAccess
+```
+
+Output:
+
+```text
 dn: olcDatabase={-1}frontend,cn=config
 olcAccess: {0}to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external
  ,cn=auth manage by * break
@@ -57,7 +68,7 @@ to attrs=userPassword
     by self write
     by anonymous auth
     by * none
-    
+
 to attrs=shadowLastChange
     by self write
     by * read
@@ -87,15 +98,18 @@ If this is unwanted then you need to change the ACL. To force authentication dur
 There is no administrative account ("Root DN") created for the `slapd-config` database. There is, however, a SASL identity that is granted full access to it. It represents the localhost's superuser (`root`/`sudo`). Here it is:
 
 ```text
-dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth 
+dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth
 ```
 
-The following command will display the ACLs of the `slapd-config` database:
+The following command displays the ACLs of the `slapd-config` database:
 
 ```bash
-$ sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b \
-cn=config '(olcDatabase={0}config)' olcAccess
-    
+sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=config '(olcDatabase={0}config)' olcAccess
+```
+
+Output:
+
+```text
 dn: olcDatabase={0}config,cn=config
 olcAccess: {0}to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,
               cn=external,cn=auth manage by * break
@@ -107,11 +121,40 @@ Since this is a SASL identity we need to use a SASL **mechanism** when invoking 
 
 - The EXTERNAL mechanism works via **Inter-process Communication** (IPC, UNIX domain sockets). This means you must use the `ldapi` URI format.
 
-A succinct way to get all the ACLs is like this:
+(ldap-peercred-setup)=
+## Grant root passwordless access to the data tree
+
+By default, the local root user can manage `cn=config` via SASL EXTERNAL, but not the data tree (`dc=example,dc=com`). To allow root to also manage the data tree without entering a password, add an ACL rule.
+
+Create a file called `peercred.ldif`:
+
+```text
+# Allow root user (via peercred) to manage the primary database (mdb)
+dn: olcDatabase={1}mdb,cn=config
+changetype: modify
+add: olcAccess
+# Inserted as the first ACL rule
+olcAccess: {0}to * by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage by * break
+```
+
+Apply the change:
 
 ```bash
-$ sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b \
-cn=config '(olcAccess=*)' olcAccess olcSuffix
+sudo ldapmodify -Q -Y EXTERNAL -H ldapi:/// -f peercred.ldif
+```
+
+Now you can run LDAP commands to modify the data tree, as root, without a LDAP password (when you run this on the OpenLDAP server machine):
+
+```bash
+sudo ldapadd -Q -Y EXTERNAL -H ldapi:/// -f add_content.ldif
+```
+
+This simplifies administration and is used throughout the other guides in this series.
+
+A succinct way to get all the ACLs is:
+
+```bash
+sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=config '(olcAccess=*)' olcAccess olcSuffix
 ```
 
 ## Next steps
@@ -121,4 +164,4 @@ See how to {ref}`set up LDAP users and groups <ldap-users-and-groups>`.
 ## Further reading
 
 - See the manual page for {manpage}`slapd.access(5)`
-- The [access control topic](https://openldap.org/doc/admin25/guide.html#Access%20Control) in the OpenLDAP administrator's guide.
+- The [access control topic](https://openldap.org/doc/admin26/guide.html#Access%20Control) in the OpenLDAP administrator's guide.

--- a/docs/how-to/openldap/backup-and-restore.md
+++ b/docs/how-to/openldap/backup-and-restore.md
@@ -1,65 +1,115 @@
 ---
 myst:
   html_meta:
-    description: Back up and restore OpenLDAP databases including configuration backend and DIT using slapcat and shell scripts.
+    description: Back up and restore OpenLDAP configuration and data using slapcat and systemd timers.
 ---
 
 (ldap-backup-and-restore)=
 # Backup and restore OpenLDAP
 
-Now we have LDAP running just the way we want, it is time to ensure we can save all of our work and restore it as needed.
+Once you have LDAP running the way you want, it is time to ensure you can save all your work and restore it as needed.
 
-What we need is a way to back up the directory database(s) -- specifically the configuration backend (`cn=config`) and the {term}`DIT` (`dc=example,dc=com`). If we are going to backup those databases into, say, `/export/backup`, we could use `slapcat` as shown in the following script, called `/usr/local/bin/ldapbackup`:
+What we need is a way to back up the directory database(s) -- specifically the configuration backend (`cn=config`) and the {term}`DIT` (`dc=example,dc=com`).
+
+## Backup script
+
+Create `/usr/local/bin/ldapbackup` with the following content:
 
 ```bash
 #!/bin/bash
-
-set -e
+set -euo pipefail
 
 BACKUP_PATH=/export/backup
-SLAPCAT=/usr/sbin/slapcat
+CONFIG_BACKUP=f${BACKUP_PATH}/config.ldif"
+DATA_BACKUP="${BACKUP_PATH}/example.com.ldif"
 
-nice ${SLAPCAT} -b cn=config > ${BACKUP_PATH}/config.ldif
-nice ${SLAPCAT} -b dc=example,dc=com > ${BACKUP_PATH}/example.com.ldif
-chown root:root ${BACKUP_PATH}/*
-chmod 600 ${BACKUP_PATH}/*.ldif
+# create and secure backup files
+touch "$CONFIG_BACKUP" "$DATA_BACKUP"
+chmod 600 "$CONFIG_BACKUP" "$DATA_BACKUP"
+
+# Backup server config
+nice slapcat -b cn=config > "$CONFIG_BACKUP"
+# Backup directory tree
+nice slapcat -b dc=example,dc=com > "$DATA_BACKUP"
+
+# Optionally, use a backup tool like borgbackup to store the backups off-site
+```
+
+Make it executable:
+
+```bash
+sudo chmod +x /usr/local/bin/ldapbackup
 ```
 
 ```{note}
-These files are uncompressed text files containing everything in your directory including the tree layout, usernames, and every password. So, you might want to consider making `/export/backup` an encrypted partition and even having the script encrypt those files as it creates them. Ideally you should do both, but that depends on your security requirements.
+These files are uncompressed text files containing everything in your directory including the tree layout, usernames, and every password. Consider making `/export/backup` an encrypted partition and even having the script encrypt files as it creates them.
 ```
 
-Then, it is just a matter of having a cron script to run this program as often as you feel comfortable with. For many, once a day suffices. For others, more often is required. Here is an example of a cron script called `/etc/cron.d/ldapbackup` that is run every night at 22:45h:
+## Schedule backups with systemd
 
-```text
-MAILTO=backup-emails@domain.com
-45 22 * * *  root    /usr/local/bin/ldapbackup
+Create a systemd service unit at `/etc/systemd/system/ldapbackup.service`:
+
+```ini
+[Unit]
+Description=LDAP backup
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/ldapbackup
+```
+
+Create a timer unit at `/etc/systemd/system/ldapbackup.timer`:
+
+```ini
+[Unit]
+Description=Run LDAP backup daily
+
+[Timer]
+OnCalendar=*-*-* 22:45:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable and start the timer:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now ldapbackup.timer
+```
+
+Verify the timer is active:
+
+```bash
+systemctl list-timers ldapbackup.timer
 ```
 
 Now the files are created, they should be copied to a backup server.
 
-Assuming we did a fresh reinstall of LDAP, the restore process could be something like this:
+## Restore script
+
+Assuming a fresh reinstall of LDAP, create `/usr/local/bin/ldaprestore`:
 
 ```bash
 #!/bin/bash
-
-set -e
+set -euo pipefail
 
 BACKUP_PATH=/export/backup
-SLAPADD=/usr/sbin/slapadd
 
-if [ -n "$(ls -l /var/lib/ldap/* 2>/dev/null)" -o -n "$(ls -l /etc/ldap/slapd.d/* 2>/dev/null)" ]; then
-    echo Run the following to remove the existing db:
-    echo sudo systemctl stop slapd.service
-    echo sudo rm -rf /etc/ldap/slapd.d/* /var/lib/ldap/*
+if [ -n "$(ls -l /var/lib/ldap/* 2>/dev/null)" ] || [ -n "$(ls -l /etc/ldap/slapd.d/* 2>/dev/null)" ]; then
+    echo "Existing database found. Run the following to remove it:"
+    echo "  sudo systemctl stop slapd.service"
+    echo "  sudo rm -rf /etc/ldap/slapd.d/* /var/lib/ldap/*"
     exit 1
 fi
+
 sudo systemctl stop slapd.service || :
-sudo slapadd -F /etc/ldap/slapd.d -b cn=config -l /export/backup/config.ldif
-sudo slapadd -F /etc/ldap/slapd.d -b dc=example,dc=com -l /export/backup/example.com.ldif
+sudo slapadd -F /etc/ldap/slapd.d -b cn=config -l ${BACKUP_PATH}/config.ldif
+sudo slapadd -F /etc/ldap/slapd.d -b dc=example,dc=com -l ${BACKUP_PATH}/example.com.ldif
 sudo chown -R openldap:openldap /etc/ldap/slapd.d/
 sudo chown -R openldap:openldap /var/lib/ldap/
 sudo systemctl start slapd.service
 ```
 
-This is a simplistic backup strategy, of course. It's being shown here as a reference for the basic tooling you can use for backups and restores.
+This is a basic backup strategy shown here as a reference for the tooling available for backups and restores.

--- a/docs/how-to/openldap/install-openldap.md
+++ b/docs/how-to/openldap/install-openldap.md
@@ -1,41 +1,50 @@
 ---
 myst:
   html_meta:
-    description: Install and configure OpenLDAP server with slapd daemon, set up database suffix, and manage hierarchical directory data on Ubuntu.
+    description: Install and configure an OpenLDAP server with slapd on Ubuntu.
 ---
 
 (install-openldap)=
 # Install and configure LDAP
 
-[Lightweight Directory Access Protocol](https://ldap.com/) (LDAP) is a protocol used for managing hierarchical data. OpenLDAP is the open-source implementation of LDAP used in Ubuntu. For information about OpenLDAP and explanations of the key terminology, see {ref}`introduction-to-openldap`.
+[Lightweight Directory Access Protocol](https://ldap.com/) (LDAP) is a protocol for managing hierarchical data. OpenLDAP is the open-source implementation of LDAP used in Ubuntu. For information about OpenLDAP and explanations of the key terminology, see {ref}`introduction-to-openldap`.
 
-Installing [slapd (the Stand-alone LDAP Daemon)](https://www.openldap.org/software/man.cgi?query=slapd) creates a minimal working configuration with a top level entry, and an administrator's Distinguished Name (DN). 
+Installing [slapd (the Stand-alone LDAP Daemon)](https://www.openldap.org/software/man.cgi?query=slapd) creates a minimal working configuration with a top level entry, and an administrator's Distinguished Name (DN).
 
-In particular, it creates a database instance that you can use to store your data. However, the **suffix** (or **base DN**) of this instance will be determined from the domain name of the host. If you want something different, you can change it right after the installation (before it contains any useful data).
+In particular, it creates a database instance to store your data. However, the **suffix** (or **base DN**) of this instance is determined from the host's domain name. If you want something different, you can change it right after installation.
 
 ```{note}
-This guide will use a database suffix of **`dc=example,dc=com`**. You can change this to match your particular setup.
+This guide uses a database suffix of **`dc=example,dc=com`**. Change this to match your particular setup.
 ```
 
 ## Install slapd
 
-You can install the server and the main command line utilities with the following command:
+Install the server and the main command line utilities:
 
-```console
+```bash
 sudo apt install slapd ldap-utils
 ```
 
+The installer prompts for an administrator password. This password is for the `cn=admin,dc=example,dc=com` DN (where `dc=example,dc=com` is derived from your system's domain name). If you leave it empty, the admin entry is created without a password and you must rely on SASL EXTERNAL authentication via Unix socket as root.
+
 ### Change the instance suffix (optional)
 
-If you want to change your Directory Information Tree ({term}`DIT`) suffix, now would be a good time since changing it discards your existing one. To change the suffix, run the following command:
+The suffix (or base DN) is the top-most entry in your directory tree, under which all other entries are created. If you want to change the suffix, now is a good time since changing it discards the existing database.
 
-```console
+To reconfigure `slapd`, run:
+
+```bash
 sudo dpkg-reconfigure slapd
 ```
 
-To switch your DIT suffix to **`dc=example,dc=com`**, for example, so you can follow this guide more closely, answer `example.com` when asked about the {term}`DNS` domain name.
+The reconfiguration wizard prompts for:
 
-Throughout this guide we will issue many commands with the LDAP utilities. To save some typing, we can configure the OpenLDAP libraries with certain defaults in `/etc/ldap/ldap.conf` (adjust these entries for your server name and directory suffix):
+1. **DNS domain name** — This determines your suffix. For example, entering `example.com` creates the suffix `dc=example,dc=com`.
+1. **Organisation name** — Stored as the `o` attribute of the base DN entry.
+1. **Administrator password** — This is the password for `cn=admin,dc=example,dc=com`.
+1. **Move old database** — The wizard offers to move the previous database to `/var/backups/`. Accept this if you want to keep the old data.
+
+Throughout this guide we will issue many commands with the LDAP utilities. To save some typing, configure the OpenLDAP libraries with defaults in `/etc/ldap/ldap.conf` (adjust for your server name and directory suffix):
 
 ```text
 BASE dc=example,dc=com
@@ -44,7 +53,11 @@ URI ldap://ldap01.example.com
 
 ## Default tree contents
 
-`slapd` is designed to be configured within the service itself by dedicating a separate DIT for that purpose. This allows for dynamic configuration of `slapd` without needing to restart the service or edit config files. This configuration database consists of a collection of text-based LDIF files located under `/etc/ldap/slapd.d`, but these should never be edited directly. This way of working is known by several names: the "slapd-config" method, the "Real Time Configuration (RTC)" method, or the "cn=config" method. You can still use the traditional flat-file method (`slapd.conf`) but that will not be covered in this guide.
+`slapd` is designed to be configured within the service itself by dedicating a separate DIT for that purpose. This allows for dynamic configuration of `slapd` without needing to restart the service or edit config files. This configuration database consists of a collection of text-based LDIF files located under `/etc/ldap/slapd.d`, but these should never be edited directly. This way of working is known by several names: the "slapd-config" method, the "Real Time Configuration (RTC)" method, or the "cn=config" method. You can still use the traditional flat-file method (`slapd.conf`) but that is not covered in this guide.
+
+```{note}
+Although the configuration is accessible via the LDAP protocol under the `cn=config` suffix, it is also stored on disk under `/etc/ldap/slapd.d/`. This allows the configuration to be replicated to other servers and backed up alongside the data.
+```
 
 Right after installation, you will get two databases, or suffixes: one for your data, which is based on your host's domain (**`dc=example,dc=com`**), and one for your configuration, with its root at **`cn=config`**. To change the data on each we need different credentials and access methods:
 
@@ -194,6 +207,8 @@ dn:gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth
 ```
 
 When using SASL EXTERNAL via the `ldapi:///` transport, the Bind DN becomes a combination of the {term}`uid` and {term}`gid` of the connecting user, followed by the suffix `cn=peercred,cn=external,cn=auth`. The server ACLs know about this, and grant the local root user complete write access to `cn=config` via the SASL mechanism.
+
+You can extend this to grant the local root user write access to your data tree as well, which simplifies administration by avoiding password prompts. See {ref}`ldap-access-control` for how to set this up.
 
 ```{note}
 OpenLDAP ACLs are explained in {ref}`Set up access control <ldap-access-control>`
@@ -426,8 +441,8 @@ modifying entry "olcDatabase={1}mdb,cn=config"
 
 You can confirm the change with a search:
 
-```console
-ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=config '(olcDatabase={1}mdb)' olcDbIndex
+```bash
+sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=config '(olcDatabase={1}mdb)' olcDbIndex
 ```
 
 And the result will include all instances of the `olcDbIndex` attribute:
@@ -447,7 +462,9 @@ To learn more about OpenLDAP indexes, check the upstream documentation at https:
 
 ### Add a schema
 
-Schemas can only be added to `cn=config` if they are in LDIF format. If not, they will first have to be converted. You can find unconverted schemas in addition to converted ones in the `/etc/ldap/schema` directory.
+A schema defines the structure and data types of object classes available in the LDAP tree. It specifies which attributes an entry can have and their syntax rules.
+
+Schemas can only be added to `cn=config` if they are in LDIF format. If not, they must first be converted. You can find unconverted schemas in addition to converted ones in the `/etc/ldap/schema` directory.
 
 ```{note}
 It is not trivial to remove a schema from the slapd-config database. Practice adding schemas on a test system.
@@ -468,11 +485,11 @@ If the schema you want to add does not exist in LDIF format, a nice conversion t
 
 ## Logging
 
-Activity logging for `slapd` is very useful when implementing an OpenLDAP-based solution -- and it must be manually enabled after software installation. Otherwise, only rudimentary messages will appear in the logs. Logging, like any other such configuration, is enabled via the `slapd-config` database.
+Activity logging for `slapd` is useful when implementing an OpenLDAP-based solution, and must be manually enabled after installation. Otherwise, only rudimentary messages appear in the logs. Logging, like any other configuration, is enabled via the `slapd-config` database.
 
 OpenLDAP comes with multiple logging levels, with each level containing the lower one (additive). A good level to try is **stats**. The {manpage}`slapd-config(5)` manual page has more to say on the different subsystems.
 
-### Example logging with the stats level 
+### Example logging with the stats level
 
 Create the file `logging.ldif` with the following contents:
 
@@ -485,30 +502,16 @@ olcLogLevel: stats
 
 Run `ldapmodify` to implement the change:
 
-```console
+```bash
 sudo ldapmodify -Q -Y EXTERNAL -H ldapi:/// -f logging.ldif
 ```
 
-Depending on how active your OpenLDAP server is, this will produce a significant amount of logging. It is recommended to revert back to a less verbose level once the need for this detailed logging isn't there anymore.
+Depending on how active your OpenLDAP server is, this may produce a significant amount of logging. Revert to a less verbose level once the need for detailed logging is gone.
 
-While in this verbose mode your host's syslog engine (`rsyslog`) may have a hard time keeping up. If you see log message like this, it means some messages were dropped:
+View the logs with:
 
-```text
-rsyslogd-2177: imuxsock lost 228 messages from pid 2547 due to rate-limiting
-```
-
-You may consider a change to `rsyslog`'s configuration. In `/etc/rsyslog.conf`, add:
-
-```text
-# Disable rate limiting
-# (default is 200 messages in 5 seconds; below we make the 5 become 0)
-$SystemLogRateLimitInterval 0
-```
-
-And then restart the `rsyslog` daemon:
-
-```console
-sudo systemctl restart syslog.service
+```bash
+sudo journalctl -eu slapd.service
 ```
 
 ## Next steps

--- a/docs/how-to/openldap/ldap-and-tls.md
+++ b/docs/how-to/openldap/ldap-and-tls.md
@@ -1,16 +1,19 @@
 ---
 myst:
   html_meta:
-    description: Secure OpenLDAP authentication with Transport Layer Security (TLS) by creating certificates and configuring encrypted sessions.
+    description: Secure OpenLDAP connections with Transport Layer Security (TLS).
 ---
 
 (ldap-and-tls)=
 # LDAP and Transport Layer Security (TLS)
 
-
 When authenticating to an OpenLDAP server it is best to do so using an encrypted session. This can be accomplished using Transport Layer Security (TLS).
 
-Here, we will act as our own Certificate Authority (CA) and create and sign the LDAP server certificate as that CA. This guide will use the `certtool` utility to complete these tasks. For simplicity, this is being done on the OpenLDAP server itself, but your real internal CA should be elsewhere.
+Here, we will act as our Certificate Authority (CA) and create and sign the LDAP server certificate as that CA. This guide will use the `certtool` utility to complete these tasks. For simplicity, this is being done on the OpenLDAP server itself, but your real internal CA should be elsewhere.
+
+```{note}
+For general information on managing certificates in Ubuntu, see {ref}`certificates`. For installing a custom root CA, see {ref}`install-a-root-ca`.
+```
 
 Install the `gnutls-bin` and `ssl-cert` packages:
 
@@ -43,13 +46,18 @@ sudo certtool --generate-self-signed \
 ```
 
 ```{note}
-Yes, the `--outfile` path is correct. We are writing the CA certificate to `/usr/local/share/ca-certificates`. This is where `update-ca-certificates` will pick up trusted local CAs from. To pick up CAs from `/usr/share/ca-certificates`, a call to `dpkg-reconfigure ca-certificates` is necessary.
+The `--outfile` path is correct. We are writing the CA certificate to `/usr/local/share/ca-certificates`. This is where `update-ca-certificates` picks up trusted local CAs from. To selectively enable CAs from `/usr/share/ca-certificates`, you can run `dpkg-reconfigure ca-certificates`.
 ```
 
 Run `update-ca-certificates` to add the new CA certificate to the list of trusted CAs. Note the one added CA:
 
 ```bash
-$ sudo update-ca-certificates
+sudo update-ca-certificates
+```
+
+Output:
+
+```text
 Updating certificates in /etc/ssl/certs...
 1 added, 0 removed; done.
 Running hooks in /etc/ca-certificates/update.d...
@@ -140,14 +148,24 @@ Note that *StartTLS* will be available without the change above, and does NOT ne
 Test *StartTLS*:
 
 ```bash
-$ ldapwhoami -x -ZZ -H ldap://ldap01.example.com
+ldapwhoami -x -ZZ -H ldap://ldap01.example.com
+```
+
+Output:
+
+```text
 anonymous
 ```
 
 Test LDAPS:
 
 ```bash
-$ ldapwhoami -x -H ldaps://ldap01.example.com
+ldapwhoami -x -H ldaps://ldap01.example.com
+```
+
+Output:
+
+```text
 anonymous
 ```
 
@@ -237,13 +255,23 @@ Like before, if you want to enable LDAPS, edit `/etc/default/slapd` and add `lda
 Test *StartTLS*:
 
 ```bash
-$ ldapwhoami -x -ZZ -H ldap://ldap02.example.com
+ldapwhoami -x -ZZ -H ldap://ldap02.example.com
+```
+
+Output:
+
+```text
 anonymous
 ```
 
 Test LDAPS:
 
 ```bash
-$ ldapwhoami -x -H ldaps://ldap02.example.com
+ldapwhoami -x -H ldaps://ldap02.example.com
+```
+
+Output:
+
+```text
 anonymous
 ```

--- a/docs/how-to/openldap/ldap-client.md
+++ b/docs/how-to/openldap/ldap-client.md
@@ -20,6 +20,7 @@ Ubuntu also supports [SSSD](https://sssd.io/) as an alternative LDAP client. SSS
 - A reachable LDAP server. To set one up, see {ref}`install-openldap`.
 - The server's base Distinguished Name ({term}`DN`) and URI.
 - The system CA certificates must trust the LDAP server's TLS certificate. See {ref}`ldap-and-tls` for guidance on TLS setup.
+- And of course {ref}`users/groups in LDAP <ldap-users-and-groups>`.
 
 ## Install the LDAP client daemon
 

--- a/docs/how-to/openldap/ldap-client.md
+++ b/docs/how-to/openldap/ldap-client.md
@@ -1,0 +1,277 @@
+---
+myst:
+  html_meta:
+    description: Configure an Ubuntu system as an LDAP client using nslcd and NSS to make directory users and groups available for local authentication.
+---
+
+(ldap-client)=
+# Set up an LDAP client
+
+This guide explains how to configure an Ubuntu machine as a [Lightweight Directory Access Protocol (LDAP)](https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol) client, so that users and groups stored in an LDAP directory become available on the system for authentication. This enables users to log in via SSH or other services backed by [Pluggable Authentication Modules (PAM)](https://en.wikipedia.org/wiki/Pluggable_Authentication_Module) using their LDAP credentials.
+
+The approach used here is `nslcd` with `libnss-ldapd` and `libpam-ldapd`. The Name Service Switch ({term}`NSS`) and PAM modules communicate with the `nslcd` daemon, which maintains a single shared LDAP connection rather than each process opening its own. This keeps the setup lightweight and easy to debug.
+
+```{note}
+Ubuntu also supports [SSSD](https://sssd.io/) as an alternative LDAP client. SSSD provides credential caching and offline authentication. If you need those features, see {ref}`sssd-with-ldap` instead.
+```
+
+## Prerequisites
+
+- A reachable LDAP server. To set one up, see {ref}`install-openldap`.
+- The server's base Distinguished Name ({term}`DN`) and URI.
+- The system CA certificates must trust the LDAP server's TLS certificate. See {ref}`ldap-and-tls` for guidance on TLS setup.
+
+## Install the LDAP client daemon
+
+Install `nslcd` and its PAM integration library:
+
+```bash
+sudo apt install nslcd libpam-ldapd libnss-ldapd
+```
+
+The installer prompts for your LDAP server URI and base DN. For example:
+
+- **LDAP server URI:** `ldaps://ldap.example.com`
+- **Base DN:** `dc=example,dc=com`
+
+Installing `libnss-ldapd` updates `/etc/nsswitch.conf` to include `ldap` as a source for `passwd`, `group`, and `shadow` lookups.
+
+## Configure nslcd
+
+Review and adjust `/etc/nslcd.conf`. A minimal configuration looks like this:
+
+```text
+# /etc/nslcd.conf
+uid nslcd
+gid nslcd
+
+uri ldaps://ldap.example.com
+
+base dc=example,dc=com
+
+tls_reqcert demand
+tls_cacertfile /etc/ssl/certs/ca-certificates.crt
+```
+
+Adjust `uri` and `base` to match your directory. The `tls_reqcert demand` setting ensures the server certificate is verified. See {manpage}`nslcd.conf(5)` for all available options.
+
+## Set up PAM
+
+The installer updates `/etc/pam.d/common-*` automatically. To confirm that LDAP authentication and automatic home directory creation are enabled, run:
+
+```bash
+sudo pam-auth-update
+```
+
+Select **LDAP Authentication** and **Create home directory on login** in the interactive menu.
+
+Restart `nslcd` to apply the configuration:
+
+```bash
+sudo systemctl restart nslcd
+```
+
+## Test the configuration
+
+Verify that a known LDAP user is visible to the system:
+
+```bash
+id <username>
+```
+
+List all users known to {term}`NSS`, including those from LDAP:
+
+```bash
+getent passwd
+```
+
+List all groups:
+
+```bash
+getent group
+```
+
+If the output includes users and groups from the LDAP directory, {term}`NSS` integration is working correctly.
+
+If this doesn't work, you can inspect live LDAP queries.
+Stop the `nslcd` service and run it in the foreground in "debug" mode:
+
+```bash
+sudo systemctl stop nslcd.service
+sudo nslcd -n -d
+```
+
+Press {kbd}`Ctrl+C` to stop this debug session.
+
+You can iterate with configuration or setup adjustments until the log output and `getent` results are satisfying.
+
+
+Finally, restart the service via {ref}`systemctl`:
+
+```bash
+sudo systemctl start nslcd.service
+```
+
+
+## Configure home directories
+
+By default, `nslcd` uses the `homeDirectory` attribute from the LDAP directory. You can remap this — or any other {manpage}`passwd(5)` field — in `/etc/nslcd.conf` using `map` directives. For example, to construct home directory paths locally regardless of what the LDAP directory provides:
+
+```text
+map passwd homeDirectory /home/$uid
+```
+
+See {manpage}`nslcd.conf(5)` for the full list of mappable attributes.
+
+## Restrict login access
+
+By default, all users visible via LDAP can log in. To restrict which users are permitted, use `pam_access`.
+
+Edit `/etc/security/access.conf` to define the allowed users and groups:
+
+```conf
+# Allow members of specific LDAP groups
++:(some-admin-group) (some-user-group):ALL
+# Allow the local root user and members of the local "login" group (group name is customizable)
++:root (login):ALL
+# Deny everyone else
+-:ALL:ALL
+```
+
+Replace `some-admin-group` and `some-user-group` with your actual LDAP group names.
+
+To process this config file, activate the `pam_access` module by creating a PAM configuration snippet at `/usr/share/pam-configs/ldap-access`:
+
+```text
+Name: LDAP group-based login access
+Default: yes
+Priority: 128
+Auth-Type: Additional
+Auth:
+        required    pam_access.so nodefgroup
+Account-Type: Primary
+Account:
+        required    pam_access.so nodefgroup
+Session-Type: Additional
+Session:
+        required    pam_access.so nodefgroup
+```
+
+Apply the configuration to add these modules to `/etc/pam.d/common-*`:
+
+```bash
+sudo pam-auth-update --enable ldap-access --enable ldap --enable mkhomedir
+```
+
+```{note}
+Local users not in any listed LDAP group can be permitted to log in by adding them to a local `login` group.
+The `login` group is allowed to log in through `/etc/security/access.conf`, see above.
+Create the group and add users as needed:
+
+    sudo groupadd -r login
+    sudo usermod -aG login <username>
+```
+
+## Grant sudo access to an LDAP group
+
+You can grant "administration privileges" via `sudo` through group memberships in your LDAP directory.
+
+To allow members of an LDAP group to use `sudo` access, add an entry to `/etc/sudoers` using {manpage}`visudo(8)`:
+
+```text
+%your-admin-group   ALL=(ALL) ALL
+```
+
+To allow `sudo` usage without entering a password, add this entry instead using {manpage}`visudo(8)`:
+```text
+%your-admin-group   ALL=(ALL) NOPASSWD: ALL
+```
+
+Replace `your-admin-group` with the relevant LDAP group name.
+Granting `sudo` access with a remote group like this is no different from using local groups.
+
+## Retrieve SSH public keys from LDAP
+
+If your LDAP schema stores SSH public keys (for example in the `sshPublicKey` attribute), you can configure `sshd` to retrieve them automatically. Add the following to `/etc/ssh/sshd_config`:
+
+```text
+AuthorizedKeysCommand /usr/local/bin/ssh-ldap-key %u
+AuthorizedKeysCommandUser nobody
+```
+
+The following Python script can serve as `/usr/local/bin/ssh-ldap-key`. It performs an anonymous LDAP search for the given username and prints any `sshPublicKey` values it finds. Install the `python3-ldap3` package before use:
+
+```bash
+sudo apt install python3-ldap3
+```
+
+```python
+#!/usr/bin/env python3
+"""Fetch SSH public keys for a user from an LDAP directory."""
+
+import argparse
+import logging
+import ldap3
+
+
+def main():
+    cli = argparse.ArgumentParser(description="SSH key fetcher from LDAP")
+    cli.add_argument("username")
+    cli.add_argument("--ldap-server", default="ldaps://ldap.example.com")
+    cli.add_argument("--base-dn", default="dc=example,dc=com")
+    cli.add_argument("--verbose", "-v", action="count", default=0)
+    args = cli.parse_args()
+
+    log_level = (logging.WARNING, logging.INFO, logging.DEBUG)[min(args.verbose, 2)]
+    logging.basicConfig(level=log_level, format="[%(asctime)s] %(message)s")
+
+    for key in fetch_keys(args.username, args.ldap_server, args.base_dn):
+        print(key)
+
+
+def fetch_keys(user, server, basedn):
+    conn = ldap3.Connection(server)
+    if not conn.bind():
+        raise RuntimeError(f"anonymous bind to {server!r} failed")
+
+    uid = ldap3.utils.conv.escape_filter_chars(user)
+    ok = conn.search(
+        basedn,
+        f"(&(objectClass=inetOrgPerson)(uid={uid}))",
+        attributes=["sshPublicKey"],
+    )
+    if not ok:
+        raise RuntimeError(f"LDAP search failed: {conn.result}")
+    if not conn.entries:
+        return []
+    if len(conn.entries) > 1:
+        raise RuntimeError(f"ambiguous username: {len(conn.entries)} entries returned")
+
+    return [
+        ldap3.utils.conv.to_unicode(key)
+        for key in conn.entries[0].sshPublicKey
+    ]
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Make the script executable and owned by root:
+
+```bash
+sudo install -o root -g root -m 0755 ssh-ldap-key /usr/local/bin/ssh-ldap-key
+```
+
+After modifying `sshd_config`, restart the SSH service:
+
+```bash
+sudo systemctl restart ssh
+```
+
+## Further reading
+
+- {ref}`install-openldap`
+- {ref}`sssd-with-ldap`
+- {ref}`ldap-and-tls`
+- {manpage}`nslcd(8)`, {manpage}`nslcd.conf(5)`, {manpage}`pam_access(8)`, {manpage}`visudo(8)`

--- a/docs/how-to/openldap/replication.md
+++ b/docs/how-to/openldap/replication.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: Set up OpenLDAP replication using syncrepl for high availability with standard or delta replication in consumer-provider model.
+    description: Set up data synchronization between OpenLDAP servers for high availability using syncrepl.
 ---
 
 (ldap-replication)=
@@ -9,7 +9,7 @@ myst:
 
 The LDAP service becomes increasingly important as more networked systems begin to depend on it. In such an environment, it is standard practice to build redundancy ({term}`high availability <HA>`) into LDAP to prevent disruption should the LDAP server become unresponsive. This is done through **LDAP replication**.
 
-Replication is achieved via the Sync replication engine, **`syncrepl`**. This allows changes to be synchronized using a *Consumer - Provider* model. A detailed description of this replication mechanism can be found in the [OpenLDAP administrator's guide](https://openldap.org/doc/admin24/guide.html#LDAP%20Sync%20Replication) and in its defining [RFC 4533](https://www.rfc-editor.org/rfc/rfc4533.txt).
+Replication is achieved via the Sync replication engine, **`syncrepl`**. This allows changes to be synchronized using a *Consumer - Provider* model. A detailed description of this replication mechanism can be found in the [OpenLDAP administrator's guide](https://openldap.org/doc/admin26/guide.html#LDAP%20Sync%20Replication) and in its defining [RFC 4533](https://www.rfc-editor.org/rfc/rfc4533.txt).
 
 There are two ways to use this replication:
 
@@ -25,7 +25,7 @@ You **must** have Transport Layer Security (TLS) enabled already before proceedi
 
 ## Provider configuration - replication user
 
-Both replication strategies will need a replication user, as well as updates to the {term}`ACL`s and limits regarding this user. To create the replication user, save the following contents to a file called `replicator.ldif`:
+Both replication strategies need a replication user, as well as updates to the {term}`ACL`s and limits regarding this user. To create the replication user, save the following contents to a file called `replicator.ldif`:
 
 ```text
 dn: cn=replicator,dc=example,dc=com
@@ -36,25 +36,26 @@ description: Replication user
 userPassword: {CRYPT}x
 ```
 
-Then add it with `ldapadd`:
+Then add it. If you have set up {ref}`passwordless access for root <ldap-peercred-setup>`, you can use:
 
 ```bash
-$ ldapadd -x -ZZ -H ldap://ldap01.example.com -D cn=admin,dc=example,dc=com -W -f replicator.ldif
-Enter LDAP Password:
-adding new entry "cn=replicator,dc=example,dc=com"
+sudo ldapadd -Q -Y EXTERNAL -H ldapi:/// -f replicator.ldif
+```
+
+Otherwise, use simple bind:
+
+```bash
+ldapadd -x -ZZ -H ldap://ldap01.example.com -D cn=admin,dc=example,dc=com -W -f replicator.ldif
 ```
 
 Now set a password for it with `ldappasswd`:
 
 ```bash
-$ ldappasswd -x -ZZ -H ldap://ldap01.example.com -D cn=admin,dc=example,dc=com -W -S cn=replicator,dc=example,dc=com
-New password:
-Re-enter new password:
-Enter LDAP Password:
+ldappasswd -x -ZZ -H ldap://ldap01.example.com -D cn=admin,dc=example,dc=com -W -S cn=replicator,dc=example,dc=com
 ```
 
 ```{note}
-Please adjust the server URI in the `-H` parameter if needed to match your deployment.
+Adjust the server URI in the `-H` parameter if needed to match your deployment.
 ```
 
 The next step is to give this replication user the correct privileges, i.e.:
@@ -65,7 +66,12 @@ The next step is to give this replication user the correct privileges, i.e.:
 For that we need to update the ACLs on the provider. Since ordering matters, first check what the existing ACLs look like on the `dc=example,dc=com` tree:
 
 ```bash
-$ sudo ldapsearch -Q -Y EXTERNAL -H ldapi:/// -LLL -b cn=config '(olcSuffix=dc=example,dc=com)' olcAccess
+sudo ldapsearch -Q -Y EXTERNAL -H ldapi:/// -LLL -b cn=config '(olcSuffix=dc=example,dc=com)' olcAccess
+```
+
+Output:
+
+```text
 dn: olcDatabase={1}mdb,cn=config
 olcAccess: {0}to attrs=userPassword by self write by anonymous auth by * none
 olcAccess: {1}to attrs=shadowLastChange by self write by * read
@@ -91,8 +97,7 @@ olcLimits: dn.exact="cn=replicator,dc=example,dc=com"
 And add it to the server:
 
 ```bash
-$ sudo ldapmodify -Q -Y EXTERNAL -H ldapi:/// -f replicator-acl-limits.ldif
-modifying entry "olcDatabase={1}mdb,cn=config"
+sudo ldapmodify -Q -Y EXTERNAL -H ldapi:/// -f replicator-acl-limits.ldif
 ```
 
 ## Provider configuration - standard replication
@@ -373,6 +378,6 @@ uid: john
 
 ## References
 
-  - [Replication types, OpenLDAP Administrator's Guide](https://openldap.org/doc/admin24/guide.html#Configuring%20the%20different%20replication%20types)
-  - [LDAP Sync Replication - OpenLDAP Administrator's Guide](https://openldap.org/doc/admin24/guide.html#LDAP%20Sync%20Replication)
+  - [Replication types, OpenLDAP Administrator's Guide](https://openldap.org/doc/admin26/guide.html#Configuring%20the%20different%20replication%20types)
+  - [LDAP Sync Replication - OpenLDAP Administrator's Guide](https://openldap.org/doc/admin26/guide.html#LDAP%20Sync%20Replication)
   - [RFC 4533](https://www.rfc-editor.org/rfc/rfc4533.txt).

--- a/docs/how-to/openldap/users-and-groups.md
+++ b/docs/how-to/openldap/users-and-groups.md
@@ -8,7 +8,8 @@ myst:
 # How to set up LDAP users and groups
 
 
-Once you {ref}`have a working LDAP server <install-openldap>`, you will need to install libraries on the client that know how and when to contact it. On Ubuntu, this was traditionally done by installing the `libnss-ldap` package, but nowadays you should use the {ref}`System Security Services Daemon (SSSD) <introduction-to-network-user-authentication-with-sssd>`. To find out how to use LDAP with SSSD, refer to {ref}`our SSSD and LDAP <sssd-with-ldap>` guide.
+Once you {ref}`have a working LDAP server <install-openldap>`, you will need to install libraries on the client that know how and when to contact it.
+On Ubuntu, this can be done with {ref}`nslcd <ldap-client>` or {ref}`SSSD <introduction-to-network-user-authentication-with-sssd>`.
 
 ## User and group management - `ldapscripts`
 


### PR DESCRIPTION
### Description

Document a simple but robust way to set up a LDAP client for an existing LDAP server.

Additionally, i fixed the stuff found in #585 

---

### Related Issue

fixes #585 

### Checklist

- [X] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [X] My pull request is linked to an existing issue (if applicable).
- [ ] I have tested my changes, and they work as expected (`Could not import extension sphinx_llm.txt (exception: No module named 'sphinx_llm')`).