### PR TITLE
Add Ubuntu domain to linkchecker ignore list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -265,6 +265,7 @@ linkcheck_ignore = [
     "https://www.redbooks.ibm.com/*",
     "http://www.gnu.org/software/*",
     "https://github.com./*",
+    "https://ubuntu.com/*",
 ]
 
 # A regex list of URLs where anchors are ignored by "make linkcheck"


### PR DESCRIPTION
### Description

Following up from the weekly linkcheck report, it seems that the ubuntu.com domain now rejects the linkchecker. Adding it to the ignore list.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
