### PR TITLE
Add glossary definitions for IP, IP address, iSCSI, localhost and LTS

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1304,10 +1304,25 @@ Internet of Things
 
 IP
 Internet Protocol
-    *Work in Progress*
+    IP is a connectionless network protocol responsible for routing packets across
+    networks. It uses the IP {term}`datagram <Datagram>` as its basic unit of
+    network information.
+
+    See also:
+    * [Networking Key Concepts](https://ubuntu.com/server/docs/explanation/networking/networking-key-concepts/)
+
+    Related topic(s):
+    * Networking
 
 IP address
-    *Work in Progress*
+    An IP address is a unique numerical identifier for a device on a network. Common
+    versions include IPv4 (32-bit, i.e. 192.168.1.1) and IPv6 (128-bit).
+
+    See also:
+    * [Networking Key Concepts](https://ubuntu.com/server/docs/explanation/networking/networking-key-concepts/)
+
+    Related topic(s):
+    * Networking
 
 IPC
 Inter-Process Communication
@@ -1347,7 +1362,16 @@ Internet Systems Consortium
 
 iSCSI
 Internet Small Computer System Interface
-    *Work in Progress*
+    iSCSI is a storage protocol that carries {term}`SCSI` commands over a TCP/IP
+    network, providing access to remote storage devices as if they were locally
+    attached.
+
+    See also:
+    * [iSCSI Initiator (or client)](https://ubuntu.com/server/docs/how-to/storage/iscsi-initiator-or-client/)
+
+    Related topic(s):
+    * Networking
+    * Storage
 
 ISO
 International Organization for Standardization
@@ -1472,7 +1496,13 @@ Load-balancing
     *Work in Progress*
 
 localhost
-    *Work in Progress*
+    localhost is a {term}`hostname` that points back to the machine itself using the
+    loopback network interface. It is used to access services running locally
+    without the need for an external network. The reserved {term}`IP address` for
+    this is 127.0.0.1 (IPv4).
+
+    Related topic(s):
+    * Networking
 
 Log files
     *Work in Progress*
@@ -1493,7 +1523,13 @@ Logic Systems Incorporated
 
 LTS
 Long-Term Support
-    *Work in Progress*
+    LTS is a release policy that provides a stable version of a product for an
+    extended period of time. For example, Ubuntu LTS releases receive 5 years of
+    standard support, including security patches, bug fixes and hardware
+    compatibility updates, prioritizing stability over newer package versions.
+
+    See also:
+    * {term}`Expanded Security Maintenance <ESM>`
 
 LU
 Logical Unit

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1309,7 +1309,7 @@ Internet Protocol
     network information.
 
     See also:
-    * [Networking Key Concepts](https://ubuntu.com/server/docs/explanation/networking/networking-key-concepts/)
+    * {ref}`networking-key-concepts`
 
     Related topic(s):
     * Networking
@@ -1319,7 +1319,7 @@ IP address
     versions include IPv4 (32-bit, i.e. 192.168.1.1) and IPv6 (128-bit).
 
     See also:
-    * [Networking Key Concepts](https://ubuntu.com/server/docs/explanation/networking/networking-key-concepts/)
+    * {ref}`networking-key-concepts`
 
     Related topic(s):
     * Networking
@@ -1367,7 +1367,7 @@ Internet Small Computer System Interface
     attached.
 
     See also:
-    * [iSCSI Initiator (or client)](https://ubuntu.com/server/docs/how-to/storage/iscsi-initiator-or-client/)
+    * {ref}`iscsi-initiator-or-client`
 
     Related topic(s):
     * Networking
@@ -1529,7 +1529,7 @@ Long-Term Support
     compatibility updates, prioritizing stability over newer package versions.
 
     See also:
-    * {term}`Expanded Security Maintenance <ESM>`
+    * [Ubuntu Releases](https://documentation.ubuntu.com/project/release-team/ubuntu-releases/)
 
 LU
 Logical Unit


### PR DESCRIPTION
### Description

Adds definitions for IP, IP address, iSCSI, localhost and LTS to the glossary.

---

### Related Issue

Part of #129

---

### Commit Message for Squash Merge

Add glossary definitions for IP, IP address, iSCSI, localhost and LTS

---

### Checklist

- [X] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [X] My pull request is linked to an existing issue (if applicable).
- [X] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

I'll do a follow up PR to link the glossary terms to the first occurrence in the other doc pages when named.