### PR TITLE
Add more domains to linkcheck ignore list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -250,6 +250,10 @@ linkcheck_ignore = [
     "http://www.gnu.org/software/*",
     "https://github.com./*",
     "https://ubuntu.com/*",
+    "https://docs.ubuntu.com/*",
+    "https://snapcraft.io/*",
+    "https://people.freedesktop.org/*",
+    "https://www.squid-cache.org/Doc/config/",
 ]
 
 # A regex list of URLs where anchors are ignored by "make linkcheck"


### PR DESCRIPTION
### Description

Weekly linkcheck run reported more broken links that are only broken for bots (not humans). Adding to ignore list.


### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
