### PR TITLE
Add context7.json

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/canonical/ubuntu-server-documentation",
+  "public_key": "pk_cHOr20EuFJQCh21R6ZJ66"
+}


### PR DESCRIPTION
### Description

Adding the context7.com json file allows us to claim the Ubuntu Server docs project (as it [already exists](https://context7.com/canonical/ubuntu-server-documentation) on context7).


### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
