### PR TITLE
Add new tutorials and cheatsheet to front page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ The tutorial walks you through a fresh installation and the first steps of opera
 
 * **Installation**: {ref}`System requirements <system-requirements>` • {ref}`Basic installation <basic-installation>` • {ref}`Ubuntu Pro subscription <attach-your-ubuntu-pro-subscription>`
 * **System basics**: {ref}`Managing software <managing-software>` • {ref}`Customizing package files <changing-package-files>` • {ref}`third-party-repository-usage`
+* **The Ubuntu command line**: {ref}`welcome-to-the-terminal` • {ref}`cli-in-depth` • {ref}`cli-cheatsheet`
 
 
 ### Networking

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ The tutorial walks you through a fresh installation and the first steps of opera
 
 * **Installation**: {ref}`System requirements <system-requirements>` • {ref}`Basic installation <basic-installation>` • {ref}`Ubuntu Pro subscription <attach-your-ubuntu-pro-subscription>`
 * **System basics**: {ref}`Managing software <managing-software>` • {ref}`Customizing package files <changing-package-files>` • {ref}`third-party-repository-usage`
-* **The Ubuntu command line**: {ref}`welcome-to-the-terminal` • {ref}`cli-in-depth` • {ref}`cli-cheatsheet`
+* **The Ubuntu command line**: {ref}`welcome-to-the-terminal` • {ref}`cli-in-depth` • {ref}`command-line-cheat-sheet`
 
 
 ### Networking


### PR DESCRIPTION
### Description

Now that the tutorials have both cleared the content cache and are viewable in the docs, I'm adding them to the front page

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
