### PR TITLE
[chore] fix weekly linkcheck failures

### DIFF
--- a/docs/explanation/virtualisation/container-tools-in-the-ubuntu-space.md
+++ b/docs/explanation/virtualisation/container-tools-in-the-ubuntu-space.md
@@ -23,9 +23,9 @@ To get started with LXC containers, check out the [LXC Introduction](https://lin
 
 The [Linux Containers Daemon, or LXD](https://canonical.com/lxd) (pronounced "lex-dee") is the lightervisor, or lightweight container hypervisor. It is a system container management tool built on top of LXC. Since it is an abstraction layer away from LXC it offers a more user-friendly interface, including both a REST API and a command-line interface. The LXD API deals with "remotes", which serve images and containers. In fact, it comes with a built-in image store, so that containers can be created more quickly. 
 
-To get started with LXD from an Ubuntu Server administrator's point of view, check out our {ref}`how to get started with LXD <lxd>` guide. For a more general beginner's introduction to LXD, we [recommend this tutorial](https://documentation.ubuntu.com/lxd/latest/tutorial/) from the LXD team.
+To get started with LXD from an Ubuntu Server administrator's point of view, check out our {ref}`how to get started with LXD <lxd>` guide. For a more general beginner's introduction to LXD, we [recommend this tutorial](https://canonical.com/lxd/docs/latest/tutorial/first_steps/) from the LXD team.
 
-In addition to creating and managing containers, LXD can also be [used to create virtual machines](https://documentation.ubuntu.com/lxd/latest/howto/instances_create/#create-a-virtual-machine).
+In addition to creating and managing containers, LXD can also be [used to create virtual machines](https://canonical.com/lxd/docs/latest/howto/instances_create/#create-a-virtual-machine).
 
 ## Docker
 

--- a/docs/how-to/openldap/ldap-and-tls.md
+++ b/docs/how-to/openldap/ldap-and-tls.md
@@ -12,7 +12,7 @@ When authenticating to an OpenLDAP server it is best to do so using an encrypted
 Here, we will act as our Certificate Authority (CA) and create and sign the LDAP server certificate as that CA. This guide will use the `certtool` utility to complete these tasks. For simplicity, this is being done on the OpenLDAP server itself, but your real internal CA should be elsewhere.
 
 ```{note}
-For general information on managing certificates in Ubuntu, see {ref}`certificates`. For installing a custom root CA, see {ref}`install-a-root-ca`.
+For general information on managing certificates in Ubuntu, see {ref}`certificates`. For installing a custom root CA, see {ref}`install-a-root-ca-certificate-in-the-trust-store`.
 ```
 
 Install the `gnutls-bin` and `ssl-cert` packages:

--- a/docs/how-to/openldap/ldap-client.md
+++ b/docs/how-to/openldap/ldap-client.md
@@ -107,7 +107,7 @@ Press {kbd}`Ctrl+C` to stop this debug session.
 You can iterate with configuration or setup adjustments until the log output and `getent` results are satisfying.
 
 
-Finally, restart the service via {ref}`systemctl`:
+Finally, restart the service via `systemctl`:
 
 ```bash
 sudo systemctl start nslcd.service
@@ -130,7 +130,7 @@ By default, all users visible via LDAP can log in. To restrict which users are p
 
 Edit `/etc/security/access.conf` to define the allowed users and groups:
 
-```conf
+```text
 # Allow members of specific LDAP groups
 +:(some-admin-group) (some-user-group):ALL
 # Allow the local root user and members of the local "login" group (group name is customizable)

--- a/docs/how-to/virtualisation/lxd.md
+++ b/docs/how-to/virtualisation/lxd.md
@@ -9,15 +9,15 @@ myst:
 
 [LXD](https://canonical.com/lxd) (pronounced lex-dee) is a modern, secure, and powerful system container and virtual machine manager.
 
-It provides a unified experience for running and managing full Linux systems inside containers or virtual machines. You can access it via the command line, its [built-in graphical user interface](https://documentation.ubuntu.com/lxd/latest/howto/access_ui/), or a set of powerful [REST APIs](https://documentation.ubuntu.com/lxd/latest/restapi_landing/). 
+It provides a unified experience for running and managing full Linux systems inside containers or virtual machines. You can access it via the command line, its [built-in graphical user interface](https://canonical.com/lxd/docs/latest/howto/access_ui/), or a set of powerful [REST APIs](https://canonical.com/lxd/docs/latest/restapi_landing/). 
 
-LXD scales from one instance on a single machine [to a cluster](https://documentation.ubuntu.com/lxd/latest/explanation/clusters/) in a full data center rack, making it suitable for both development and production workloads. You can even use LXD to set up a small, scalable private cloud, [such as a MicroCloud](https://canonical.com/microcloud). 
+LXD scales from one instance on a single machine [to a cluster](https://canonical.com/lxd/docs/latest/explanation/clusters/) in a full data center rack, making it suitable for both development and production workloads. You can even use LXD to set up a small, scalable private cloud, [such as a MicroCloud](https://canonical.com/microcloud). 
 
 This document will focus on how to configure and administer LXD on Ubuntu systems using the command line. On Ubuntu Server Cloud images, LXD comes pre-installed.
 
 ## Online resources
 
-You can visit [the official LXD documentation](https://documentation.ubuntu.com/lxd/), or get in touch with the LXD team in their [Ubuntu Discourse forum](https://discourse.ubuntu.com/c/lxd/126). The team also maintains a [YouTube channel](https://www.youtube.com/c/LXDvideos) with helpful videos. 
+You can visit [the official LXD documentation](https://canonical.com/lxd/docs/default/), or get in touch with the LXD team in their [Ubuntu Discourse forum](https://discourse.ubuntu.com/c/lxd/126). The team also maintains a [YouTube channel](https://www.youtube.com/c/LXDvideos) with helpful videos. 
 
 ## Installation
 
@@ -53,7 +53,7 @@ gpasswd -a joe lxd
 
 as root to change it. The new membership will take effect on the next login, or after running `newgrp lxd` from an existing login.
 
-See [How to initialize LXD](https://documentation.ubuntu.com/lxd/latest/howto/initialize/) in the LXD documentation for more information on the configuration settings. Also, refer to the definitive configuration provided with the source code for the server, container, profile, and device configuration. 
+See [How to initialize LXD](https://canonical.com/lxd/docs/latest/howto/initialize/) in the LXD documentation for more information on the configuration settings. Also, refer to the definitive configuration provided with the source code for the server, container, profile, and device configuration. 
 
 ## Creating your first container
 
@@ -176,7 +176,7 @@ Now when the client adds r1 as a known remote, it will not need to provide a pas
 
 LXD supports several backing stores. The recommended and the default backing store is `zfs`. If you already have a ZFS pool configured, you can tell LXD to use it during the `lxd init` procedure, otherwise a file-backed `zpool` will be created automatically. With ZFS, launching a new container is fast because the {term}`filesystem` starts as a copy on write clone of the images' filesystem. Note that unless the container is privileged (see below) LXD will need to change ownership of all files before the container can start, however this is fast and change very little of the actual filesystem data.
 
-The other supported backing stores are described in detail in the [Storage configuration](https://documentation.ubuntu.com/lxd/latest/explanation/storage/) section of the LXD documentation.
+The other supported backing stores are described in detail in the [Storage configuration](https://canonical.com/lxd/docs/latest/explanation/storage/) section of the LXD documentation.
 
 ## Container configuration
 
@@ -240,7 +240,7 @@ LXD supports flexible constraints on the resources which containers can consume.
 
   - Processes: limit the number of concurrent processes in the container
 
-For a full list of limits known to LXD, see [the configuration documentation](https://documentation.ubuntu.com/lxd/latest/reference/instance_options/).
+For a full list of limits known to LXD, see [the configuration documentation](https://canonical.com/lxd/docs/latest/reference/instance_options/).
 
 ## UID mappings and privileged containers
 


### PR DESCRIPTION
### Description

This week, the linkchecker is reporting failed links from LXD, which has just completed the migration from documentation.ubuntu.com to canonical.com. There's some strange behaviour around the redirects (which work when I test them manually, but are reported as failures in the linkchecker). Have reported this to the TA for LXD for further investigation on their redirects.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
