### PR TITLE
convert bare links to ref

### DIFF
--- a/docs/explanation/active-directory/identity-mapping-idmap-backends.md
+++ b/docs/explanation/active-directory/identity-mapping-idmap-backends.md
@@ -34,5 +34,5 @@ The Active Directory domain users and groups need to fit somewhere, and the larg
 
 See next:
 
-* [The rid idmap backend](the-rid-idmap-backend.md)
-* [The autorid idmap backend](the-autorid-idmap-backend.md)
+* {ref}`The rid idmap backend <the-rid-idmap-backend>`
+* {ref}`The autorid idmap backend <the-autorid-idmap-backend>`

--- a/docs/explanation/crypto/openssl.md
+++ b/docs/explanation/crypto/openssl.md
@@ -219,7 +219,7 @@ MinProtocol = TLSv1.3
 
 Since we are already forcing TLSv1.3, there is no need to tweak the `CipherString` list, since that applies only to TLSv1.2 and older.
 
-The OpenSSL `s_server` command is very handy to test this (see [the Troubleshooting section](troubleshooting-tls-ssl.md) for details on how to use it):
+The OpenSSL `s_server` command is very handy to test this (see {ref}`the Troubleshooting section <troubleshooting-tls-ssl>` for details on how to use it):
 
 ```bash
 $ sudo openssl s_server -cert j-server.pem -key j-server.key -port 443 -www

--- a/docs/explanation/networking/about-netplan.md
+++ b/docs/explanation/networking/about-netplan.md
@@ -15,4 +15,4 @@ It is also flexible enough to be used in virtual environments and containerized 
 
 Netplan integrates with both of the primary Linux network management daemons: NetworkManager and systemd-networkd. For more general information about Netplan and how it works, see the [introduction to Netplan](https://netplan.readthedocs.io/en/stable/structure-id/) in the official Netplan documentation. 
 
-Server admins may want to get started by checking out our guide to [configuring networks](configuring-networks.md).  For more specific networking tasks with Netplan, we recommend checking out the [list of how-to guides](https://netplan.readthedocs.io/en/stable/howto/) in their documentation.
+Server admins may want to get started by checking out our guide to {ref}`configuring networks <configuring-networks>`.  For more specific networking tasks with Netplan, we recommend checking out the [list of how-to guides](https://netplan.readthedocs.io/en/stable/howto/) in their documentation.

--- a/docs/how-to/debugging/debug-symbol-packages.md
+++ b/docs/how-to/debugging/debug-symbol-packages.md
@@ -13,7 +13,7 @@ This document describes how to set up the debugging symbol packages (`*-dbg.deb`
 
 ## Debuginfod
 
-If you are on Ubuntu Jammy (22.04) or later, you don't need to worry about installing debug symbol packages since the Ubuntu project maintains a [Debuginfod](about-debuginfod.md) server. [GNU Debugger (GDB)](https://www.sourceware.org/gdb/) and other debuginfo-consumer applications support Debuginfod (mostly) out of the box. For more information about it, please refer [to our Debuginfod guide](about-debuginfod.md).
+If you are on Ubuntu Jammy (22.04) or later, you don't need to worry about installing debug symbol packages since the Ubuntu project maintains a Debuginfod server. [GNU Debugger (GDB)](https://www.sourceware.org/gdb/) and other debuginfo-consumer applications support Debuginfod (mostly) out of the box. For more information about it, please refer {ref}`to our Debuginfod guide <about-debuginfod>`.
 
 You will only need to follow the methods outlined in this section if you are on Ubuntu Focal (20.04) or earlier.
 

--- a/docs/how-to/installation/how-to-start-a-live-server-installation-on-ibm-power-ppc64el-with-a-virtual-cd-rom-and-petitboot.md
+++ b/docs/how-to/installation/how-to-start-a-live-server-installation-on-ibm-power-ppc64el-with-a-virtual-cd-rom-and-petitboot.md
@@ -8,7 +8,7 @@ myst:
 # How to start a live server installation on IBM Power (ppc64el) with a virtual CD-ROM and Petitboot
 
 :::{note}
-Not all IBM Power machines come with the capability of installing via a virtual CD-ROM! However, it is also possible to [boot the installer over the network](netboot-the-live-server-installer-on-ibm-power-ppc64el-with-petitboot.md).
+Not all IBM Power machines come with the capability of installing via a virtual CD-ROM! However, it is also possible to {ref}`boot the installer over the network <netboot-the-live-server-installer-on-ibm-power-ppc64el-with-petitboot>`.
 :::
 
 A separate system (ideally in the same network, because of `ipmitool`) is needed to host the ppc64el ISO image file, which is later used as the virtual CD-ROM.

--- a/docs/how-to/openldap/replication.md
+++ b/docs/how-to/openldap/replication.md
@@ -20,7 +20,7 @@ There are two ways to use this replication:
 The delta replication sends less data over the network, but is more complex to set up. We will show both in this guide.
 
 :::{important}
-You **must** have Transport Layer Security (TLS) enabled already before proceeding with this guide. Please consult the [LDAP with TLS guide](ldap-and-tls.md) for details of how to set this up.
+You **must** have Transport Layer Security (TLS) enabled already before proceeding with this guide. Please consult the {ref}`LDAP with TLS guide <ldap-and-tls>` for details of how to set this up.
 :::
 
 ## Provider configuration - replication user
@@ -147,7 +147,7 @@ The Provider is now configured.
 
 ## Consumer configuration - standard replication
 
-Install the software by going through [the installation steps](install-openldap.md). Make sure schemas and the database suffix are the same, and [enable TLS](ldap-and-tls.md).
+Install the software by going through {ref}`the installation steps <install-openldap>`. Make sure schemas and the database suffix are the same, and {ref}`enable TLS <ldap-and-tls>`.
 
 Create an LDIF file with the following contents and name it `consumer_simple_sync.ldif`:
 
@@ -186,7 +186,7 @@ Ensure the following attributes have the correct values:
 - **`rid`**: Replica ID, a unique 3-digit ID that identifies the replica. Each consumer should have at least one `rid`.
 
 :::{note}
-A successful encrypted connection via `START_TLS` is being enforced in this configuration, to avoid sending the credentials in the clear across the network. See [LDAP with TLS](ldap-and-tls.md/) for details on how to set up OpenLDAP with trusted SSL certificates.
+A successful encrypted connection via `START_TLS` is being enforced in this configuration, to avoid sending the credentials in the clear across the network. See {ref}`LDAP with TLS <ldap-and-tls>` for details on how to set up OpenLDAP with trusted SSL certificates.
 :::
 
 Add the new configuration:
@@ -295,7 +295,7 @@ The Provider is now configured.
 
 ## Consumer configuration
 
-Install the software by going through [the installation steps](install-openldap.md). Make sure schemas and the database suffix are the same, and [enable TLS](ldap-and-tls.md).
+Install the software by going through {ref}`the installation steps <install-openldap>`. Make sure schemas and the database suffix are the same, and {ref}`enable TLS <ldap-and-tls>`.
 
 Create an LDIF file with the following contents and name it `consumer_sync.ldif`:
 
@@ -337,7 +337,7 @@ Ensure the following attributes have the correct values:
 - **rid**: Replica ID, a unique 3-digit ID that identifies the replica. Each consumer should have at least one `rid`.
 
 :::{note}
-Note that a successful encrypted connection via `START_TLS` is being enforced in this configuration, to avoid sending the credentials in the clear across the network. See [LDAP with TLS](ldap-and-tls.md/) for details on how to set up OpenLDAP with trusted SSL certificates.
+Note that a successful encrypted connection via `START_TLS` is being enforced in this configuration, to avoid sending the credentials in the clear across the network. See {ref}`LDAP with TLS <ldap-and-tls>` for details on how to set up OpenLDAP with trusted SSL certificates.
 :::
 
 Add the new configuration:

--- a/docs/how-to/samba/file-server.md
+++ b/docs/how-to/samba/file-server.md
@@ -9,7 +9,7 @@ myst:
 
 One of the most common ways to network Ubuntu and Windows computers is to configure Samba as a *file server*. It can be set up to share files with Windows clients, as we'll see in this section. 
 
-The server will be configured to share files with any client on the network without prompting for a password. If your environment requires stricter Access Controls see [Share Access Control](share-access-controls.md).
+The server will be configured to share files with any client on the network without prompting for a password. If your environment requires stricter Access Controls see {ref}`Share Access Control <share-access-controls>`.
 
 :::{warning}
 If you use **Samba and authd** at the same time, you must specify user and group mapping. Otherwise, you will encounter permission issues due to mismatched user and group identifiers.
@@ -94,7 +94,7 @@ sudo systemctl restart smbd.service nmbd.service
 ```
 
 :::{warning}
-Once again, the above configuration gives full access to any client on the local network. For a more secure configuration see [Share Access Control](share-access-controls.md).
+Once again, the above configuration gives full access to any client on the local network. For a more secure configuration see {ref}`Share Access Control <share-access-controls>`.
 :::
 
 From a Windows client you should now be able to browse to the Ubuntu file server and see the shared directory. If your client doesn't show your share automatically, try to access your server by its IP address, e.g. `\\192.168.1.1`, in a Windows Explorer window. To check that everything is working try creating a directory from Windows.

--- a/docs/how-to/samba/nt4-domain-controller-legacy.md
+++ b/docs/how-to/samba/nt4-domain-controller-legacy.md
@@ -149,7 +149,7 @@ With a Primary Domain Controller (PDC) on the network it is best to have a Backu
 
 When configuring Samba as a BDC you need a way to sync account information with the PDC. There are multiple ways of accomplishing this; secure copy protocol (SCP), `rsync`, or by using LDAP as the `passdb` backend.
 
-Using LDAP is the most robust way to sync account information, because both domain controllers can use the same information in real time. However, setting up an LDAP server may be overly complicated for a small number of user and computer accounts. See [Samba - OpenLDAP Backend](openldap-backend-legacy.md) for details.
+Using LDAP is the most robust way to sync account information, because both domain controllers can use the same information in real time. However, setting up an LDAP server may be overly complicated for a small number of user and computer accounts. See {ref}`Samba - OpenLDAP Backend <openldap-backend-legacy>` for details.
 
 First, install `samba` and `libpam-winbind`. From a terminal enter:
 

--- a/docs/how-to/security/smart-card-authentication.md
+++ b/docs/how-to/security/smart-card-authentication.md
@@ -459,4 +459,4 @@ smart-card-authentication-with-ssh
 
 ## SSH authentication
 
-See [this page on SSH authentication with smart cards](smart-card-authentication-with-ssh.md).
+See {ref}`this page on SSH authentication with smart cards <smart-card-authentication-with-ssh>`.

--- a/docs/how-to/software/automatic-updates.md
+++ b/docs/how-to/software/automatic-updates.md
@@ -38,7 +38,8 @@ Right after installation, automatic installation of security updates will be ena
 
 
 ## Enabling and disabling unattended upgrades
-Unattended upgrades performs the equivalent of `apt update` and `apt upgrade` (see [Upgrading packages](package-management.md#upgrading-packages) for details on these commands). First, it refreshes the package lists, to become aware of the new state of the package repositories. Then it checks which upgrades are available and applies them.
+
+Unattended upgrades performs the equivalent of `apt update` and `apt upgrade` (see {ref}`Upgrading packages <upgrading-packages>` for details on these commands). First, it refreshes the package lists, to become aware of the new state of the package repositories. Then it checks which upgrades are available and applies them.
 
 These two steps are controlled via the `Update-Package-Lists` and `Unattended-Upgrade` options in `/etc/apt/apt.conf.d/20auto-upgrades`:
 ```text

--- a/docs/how-to/software/package-management.md
+++ b/docs/how-to/software/package-management.md
@@ -66,6 +66,7 @@ syntax of the two tools is identical.
 :::
 
 
+(upgrading-packages)=
 ### Upgrading packages 
 
 Installed packages on your computer may periodically have upgrades available from the package repositories (e.g., security updates). To upgrade your system, first update your package index and then perform the upgrade -- as follows:


### PR DESCRIPTION
### Description

We still had some old hardcoded links to pages, which needed to be converted to {ref} links

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### AI disclosure

I used Claude Sonnet 4.6 to find and convert all the links to point to the correct anchors
