### PR TITLE
Add another link to ignore list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -254,6 +254,7 @@ linkcheck_ignore = [
     "https://snapcraft.io/*",
     "https://people.freedesktop.org/*",
     "https://www.squid-cache.org/Doc/config/",
+    "https://tunnelblick.net/*",
 ]
 
 # A regex list of URLs where anchors are ignored by "make linkcheck"


### PR DESCRIPTION
### Description

In this week's linkcheck run, it looks like another site is refusing the linkcheck bot. The link still works in my browser, so adding to ignore list.

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
