### PR TITLE
docs(glossary.md): fix incorrect representation of gigabyte unit

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1016,7 +1016,7 @@ GFS2
 
 GB
     Gigabyte (unit of measurement)
-    1 GB = 1024 bytes
+    1 GB = 1,000,000,000 bytes
 
 GID
 Group ID


### PR DESCRIPTION
### Description

This Pull Request fixes a mistake in the Ubuntu Server `glossary.md` file stating that a Gigabyte is equal to 1024 bytes.  
1024 -> 1,000,000,000

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.

---

### Additional Notes

This is my first Pull Request to Ubuntu Server, so please be nice.
Also I'm not sure if you want it to say 1024 Megabytes (MB) so feedback is appreciated!   

---

Thank you for contributing to the Ubuntu Server documentation!
