### PR TITLE
chore: Remove trailing slash from github url to fix link created for edit-this-page-on-github

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ html_context = {
     
     # Your documentation GitHub repository URL
     # If set, links for viewing the docs source files and creating GitHub issues are added at the bottom of each page.
-    "github_url": "https://github.com/canonical/ubuntu-server-documentation/",
+    "github_url": "https://github.com/canonical/ubuntu-server-documentation",
 
     # Docs branch in the repo; used in links for viewing the source files
     "repo_default_branch": "main",


### PR DESCRIPTION
### Description

Removes trailing slash from GitHub URL in conf.py to fix link created for edit-this-page-on-github. If you check the current link to 'edit this page on GitHub' on any page, there is an extra slash after `ubuntu-server-documentation`. This leads you to a page in the GitHub repo that is stuck loading.

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.