### PR TITLE
Fix Pre-Update Apt Command

### DIFF
--- a/docs/how-to/software/upgrade-your-release.md
+++ b/docs/how-to/software/upgrade-your-release.md
@@ -41,14 +41,7 @@ Before starting a major release upgrade, it's important to prepare your system t
       :user:
       :host:
       :dir:
-      sudo apt dist-upgrade -o
-      ```
-      ```{terminal}
-      :copy:
-      :user:
-      :host:
-      :dir:
-      APT::Get::Always-Include-Phased-Updates=true
+      sudo apt dist-upgrade -o APT::Get::Always-Include-Phased-Updates=true
       ```
   2. Confirm both commands complete successfully and no further updates are available.
 


### PR DESCRIPTION
Fix Apt Command on Release-Upgrade Doc Page

### Description

This is a small fix to the documentation.

- Before, the command `sudo apt dist-upgrade -o APT::Get::Always-Include-Phased-Updates=true` was accidentally split into two, resulting in the following wrong code blocks on the [web page](https://ubuntu.com/server/docs/how-to/software/upgrade-your-release/):
<img width="2364" height="540" alt="image" src="https://github.com/user-attachments/assets/ba355891-9266-4bbd-b122-0de38b60bf5f" />
- This commit merges the second and the third command block into the correct, functional command.

---

- [X] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [ ] My pull request is linked to an existing issue (if applicable).
- [X] I have tested my changes, and they work as expected.
- [X] I have disclosed my usage of AI