### PR TITLE
update nagios 3 to 4

### DIFF
--- a/docs/how-to/observability.md
+++ b/docs/how-to/observability.md
@@ -26,6 +26,6 @@ If you do not need a full LMA stack, there are some other supported tools that c
 Set up your LMA stack <observability/set-up-your-lma-stack>
 Install Logwatch <observability/install-logwatch>
 Install Munin <observability/install-munin>
-Install Nagios Core 3 <observability/install-nagios>
+Install Nagios Core 4 <observability/install-nagios>
 Use Nagios with Munin <observability/use-nagios-with-munin>
 ```

--- a/docs/how-to/observability/install-nagios.md
+++ b/docs/how-to/observability/install-nagios.md
@@ -1,65 +1,69 @@
 ---
 myst:
   html_meta:
-    description: Install and configure Nagios Core 3 for availability monitoring of essential servers and services across multiple Ubuntu systems.
+    description: Install and configure Nagios Core 4 for availability monitoring of essential servers and services across multiple Ubuntu systems.
 ---
 
 (install-nagios)=
-# How to install and configure Nagios Core 3
+# How to install and configure Nagios Core 4
 
-:::{note}
-Nagios Core 3 has been deprecated and is now replaced by Nagios Core 4. The `nagios3` package was last supported in Bionic, so subsequent releases should use `nagios4` instead.
-:::
+The monitoring of essential servers and services is an important part of system administration. This guide walks through how to install and configure Nagios Core 4 for availability monitoring.
 
-The monitoring of essential servers and services is an important part of system administration. This guide walks through how to install and configure Nagios Core 3 for availability monitoring.
+## Installation
 
-The example in this guide uses two servers with {term}`hostnames <hostname>`: **`server01`** and **`server02`**. 
+The example in this guide uses two servers, with {term}`hostnames <hostname>` `server01` and `server02`:
 
-`Server01` will be configured with Nagios to monitor services on itself and on `server02`, while `server02` will be configured to send data to `server01`.
+* `Server01` will be configured with Nagios to monitor services on itself and on `server02`
+* `server02` will be configured to send data to `server01`
 
-## Install `nagios3` on `server01`
 
-First, on `server01`, install the `nagios3` package by entering the following command into your terminal:
+### Install Nagios Core 4 on `server01`
+
+On `server01`, install the `nagios4` package and NRPE plugin:
 
 ```{terminal}
 :copy:
-:user:
-:host:
-:dir:
-sudo apt install nagios3 nagios-nrpe-plugin
+:user: user
+:host: server01
+:dir: ~
+sudo apt install nagios4 nagios-nrpe-plugin
 ```
 
 You will be asked to enter a password for the **`nagiosadmin`** user. The user's credentials are stored in `/etc/nagios3/htpasswd.users`. To change the `nagiosadmin` password, or add more users to the Nagios CGI scripts, use the `htpasswd` that is part of the `apache2-utils` package.
 
-For example, to change the password for the `nagiosadmin` user, enter:
+The package installs Postfix by default. See {ref}`install-postfix` for details on setting this up.
+
+It is also recommended that `server01` is set up with a Fully Qualified Domain Name (FQDN). If you don't have a FQDN mail server, or want to do the configuration at a later time, choose the "No configuration" option from the Postfix Configuration dialog. Refer to the {ref}`install-dns` documentation -- the NRPE plugin package will be used to collect data from `server02`.
+
+
+### Create a user for accessing the Nagios web interface
+
+After installing Nagios 4 on `server01`, create the `nagiosadmin` user:
 
 ```{terminal}
 :copy:
-:user:
-:host:
-:dir:
-sudo htpasswd /etc/nagios3/htpasswd.users nagiosadmin
+:user: user
+:host: server01
+:dir: ~
+sudo htdigest -c /etc/nagios4/htdigest.users "Nagios4" nagiosadmin
 ```
 
-To add a user:
+Use the `-c` argument only when creating the user for the first time.
 
-```{terminal}
-:copy:
-:user:
-:host:
-:dir:
-sudo htpasswd /etc/nagios3/htpasswd.users steve
-```
+The `htdigest` tool is installed by default by Nagios Core 4 package. "`Nagios4`" here is the realm argument provided in directive `AuthName` in the `/etc/nagios4/apache2.conf` file. More information on this will be provided later when we configure the Nagios server on `server01`. For more information on the `htdigest` tool see [Nagios CGI security documentation](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/4/en/cgisecurity.html).
+
+Moving on to `server02`...
+
 
 ## Install `nagios-nrpe-server` on `server02`
 
-Next, on `server02` install the `nagios-nrpe-server` package. From a terminal on `server02` enter:
+Next, on `server02`, install the `nagios-nrpe-server` package:
 
 ```{terminal}
 :copy:
-:user:
-:host:
-:dir:
+:user: user
+:host: server02
+:dir: ~
 sudo apt install nagios-nrpe-server
 ```
 
@@ -67,198 +71,501 @@ sudo apt install nagios-nrpe-server
 NRPE allows you to execute local checks on remote hosts. There are other ways of accomplishing this through other Nagios plugins, as well as other checks.
 :::
 
-## Configuration overview
 
-There are a couple of directories containing Nagios configuration and check files.
+## Configuring the Nagios server
 
-- `/etc/nagios3`: Contains configuration files for the operation of the Nagios daemon, CGI files, hosts, etc.
+Back on `server01`...
 
-- `/etc/nagios-plugins`: Contains configuration files for the service checks.
+Before configuring the Nagios server it is important to understand the location of directories containing Nagios configuration and check files.
 
-- `/etc/nagios`: On the remote host, contains the `nagios-nrpe-server` configuration files.
+`/etc/nagios4`
+: Contains configuration files for the operation of the Nagios daemon. Most of the maintenance of the Nagios server will be performed at this location. This directory contains user authentication file `htdigest.users`, custom configuration directory `conf.d` and objects directory.
 
-- `/usr/lib/nagios/plugins/`: Where the check binaries are stored. To see the options of a check use the `-h` option. For example: `/usr/lib/nagios/plugins/check_dhcp -h`
+`/etc/nagios-plugins/config`
+: Contains configuration files for the service checks.
 
-There are multiple checks Nagios can be configured to execute for any given host. For this example, Nagios will be configured to check disk space, {term}`DNS`, and a MySQL {term}`hostgroup`. The DNS check will be on `server02`, and the MySQL hostgroup will include both `server01` and `server02`.
+`/etc/nagios`
+: On the remote host, contains the `nagios-nrpe-server` configuration files.
 
-:::{note}
-See these guides for details on {ref}`setting up Apache <introduction-to-web-services>`, {ref}`Domain Name Service <install-dns>`, and {ref}`MySQL <install-mysql>`.
-:::
+Apache files are located in the `/etc/apache2` directory.
 
-Additionally, there are some terms that once explained will hopefully make understanding Nagios configuration easier:
 
-- *Host*: A server, workstation, network device, etc. that is being monitored.
+### Enable authentication
 
-- *Host Group*: A group of similar hosts. For example, you could group all web servers, file server, etc.
+As a first step in the configuration, on `server01`, to use digest authentication, the `use_authentication` default setting must be changed. Edit the `/etc/nagios4/cgi.cfg` file and change the directive ` use_authentication=0` to ` use_authentication=1`.
 
-- *Service*: The service being monitored on the host, such as HTTP, DNS, NFS, etc.
+Save the file and close.
 
-- *Service Group*: Allows you to group multiple services together. This is useful for grouping multiple HTTP for example.
 
-- *Contact*: Person to be notified when an event takes place. Nagios can be configured to send emails, SMS messages, etc.
+### Apache configuration for Nagios
 
-By default, Nagios is configured to check HTTP, disk space, SSH, current users, processes, and load on the **localhost**. Nagios will also ping check the **gateway**.
-
-Large Nagios installations can be quite complex to configure. It is usually best to start small, with one or two hosts, to get things configured the way you want before expanding.
-
-## Configure Nagios
-
-### Create host config file for server02
-
-First, create a **host** configuration file for `server02`. Unless otherwise specified, run all these commands on `server01`. In a terminal enter:
+The Apache configuration for Nagios involves editing the default configuration `apache2.conf` file provided in `/etc/nagios4`, and enabling the web interface in Apache2. It is a good idea to create a copy of this file before working on it, so you can have the original file saved for reference. You can achieve this on `server01` by running:
 
 ```{terminal}
 :copy:
-:user:
-:host:
-:dir:
-sudo cp /etc/nagios3/conf.d/localhost_nagios2.cfg \
-/etc/nagios3/conf.d/server02.cfg
+:user: user
+:host: server01
+:dir: ~
+sudo cp /etc/nagios4/apache2.conf /etc/nagios4/apache2.conf.orig
 ```
 
-:::{note}
-In all command examples, replace "`server01`", "`server02`", `172.18.100.100`, and `172.18.100.101` with the host names and IP addresses of your servers.
-:::
-
-### Edit the host config file    
-
-Next, edit `/etc/nagios3/conf.d/server02.cfg`:
- 
-```text    
-define host{
-        use                     generic-host  ; Name of host template to use
-        host_name               server02
-        alias                   Server 02
-        address                 172.18.100.101
-}
-        
-# check DNS service.
-define service {
-        use                             generic-service
-        host_name                       server02
-        service_description             DNS
-        check_command                   check_dns!172.18.100.101
-}
-```
-
-Restart the Nagios daemon to enable the new configuration:
-
-```{terminal}
-:copy:
-:user:
-:host:
-:dir:
-sudo systemctl restart nagio3.service
-```
-
-### Add service definition
-
-Now add a service definition for the MySQL check by adding the following to `/etc/nagios3/conf.d/services_nagios2.cfg`:
-
-```text    
-# check MySQL servers.
-define service {
-        hostgroup_name        mysql-servers
-        service_description   MySQL
-        check_command         check_mysql_cmdlinecred!nagios!secret!$HOSTADDRESS
-        use                   generic-service
-        notification_interval 0 ; set > 0 if you want to be renotified
-}
-```
-
-A **mysql-servers** hostgroup now needs to be defined. Edit `/etc/nagios3/conf.d/hostgroups_nagios2.cfg` and add the following:
+On the next step, edit `/etc/nagios4/apache2.conf` to complete the digest authentication configuration for the Nagios web interface. Edit the `/etc/nagios4/apache2.conf` file, and comment out the "Require IP" directive (add a `#` in front of it):
 
 ```text
-# MySQL hostgroup.
-define hostgroup {
-        hostgroup_name  mysql-servers
-                alias           MySQL servers
-                members         localhost, server02
-        }
+#Require ip ::1/128 fc00::/7 fe80::/10 10.0.0.0/8 169.254.0.0/16 172.16.0.0/12 192.168.0.0/16
 ```
 
-The Nagios check needs to authenticate to MySQL. To add a `nagios` user to MySQL enter:
+This line was enabled by default, to only allow private IP addresses access. If that is what you need, then leave it un-commented.
+
+Inside the `<Files "cmd.cgi">` block, change or add the "Require all granted" and "Require valid-user" directives. Comment out the "Require all granted" directive and un-comment "Require valid-user". This directive forces user authentication; which is necessary to issue commands, such as to silence notifications:
+
+```text
+<Files "cmd.cgi">
+   Options  ExecCGI
+   AuthDigestDomain  "Nagios4"
+   AuthDigestProvider  file
+   AuthUserFile  "/etc/nagios4/htdigest.users"
+   AuthGroupFile "/etc/group"
+   AuthName  "Nagios4"
+   AuthType  Digest
+   #Require all  granted
+   Require  valid-user
+</Files>
+```
+
+### Force all users to authenticate
+
+The next step forces ALL users to authenticate. Comment out the following line:
+
+```text
+#<Files "cgi.cmd">
+```
+
+and its closing bracket:
+
+```text
+#</Files>
+```
+
+This has the effect of moving all directives that were inside the `<Files>` block, to the `<DirectoryMatch>` block and therefore, enforcing all users to authenticate against the matched directories paths expressed in the regex pattern.
+
+The Apache configuration file for Nagios is now configured, so save close it.
+
+:::{note}
+The Alias `/nagios4` in directive `Alias /nagios4 /usr/share/nagios4/htdocs` can be changed to be anything you need. This is how you would reach the Nagios interface from the browser. In this setup, you would enter into the browser: `server01/nagios4`.
+
+For more information on the topic of authentication and authorization, see both [Apache's documentation](https://httpd.apache.org/docs/2.2/howto/auth.html) and [Nagios's documentation](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/4/en/cgisecurity.html). If you need granular access for users, use the `/etc/nagios4/cgi.cfg` file to define the access the user is authorized for.
+:::
+
+
+## Nagios web interface
+
+At this point, the web interface is not yet working as intended.
+
+Still working on `server01`, copy the `/etc/nagios4/apache2.conf` file to the `/etc/apache2/sites-available` directory by running:
 
 ```{terminal}
 :copy:
-:user:
-:host:
-:dir:
+:user: user
+:host: server01
+:dir: ~
+sudo cp /etc/nagios4/apache2.conf /etc/apache2/sites-available/nagios4.conf
+```
+
+Then enable the configuration:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo a2ensite nagios4.conf
+```
+
+Nagios web interface Apache site is now enabled. It is time to reload both Apache2 and Nagios to apply configuration changes:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo systemctl reload apache2
+```
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo systemctl reload nagios4
+```
+
+Check the status of Nagios and Apache2. Examine the output for any errors:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo systemctl status apache2
+```
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo systemctl status nagios4
+```
+
+If both are active (running) and no errors are reported, then the web interface can be tested. For information on how to configure Apache2, refer to the {ref}`how-to configure Apache2 <install-apache2>` page.
+
+
+## Modifying the Nagios Apache site
+
+At this point, the Nagios site can be tested. From a browser, type `server01/nagios4` and press {kbd}`Enter`. Alternatively, if the hostname does not resolve to DNS, enter the IP address: `172.10.100.1/nagios4`.
+
+Replace the IP address with the IP address of your Nagios server. You will be asked to authenticate, so log in as the user `nagiosadmin` that was created earlier. You will notice that under "hosts", only the localhost is being monitored. More on working with objects later.
+
+To illustrate making modifications to the Nagios site, landing `server01/nagios4` is going to be changed to `server01/nagios`.
+
+On `server01`, edit file `/etc/nagios4/apache2.conf`, changing the line:
+
+```text
+Alias /nagios4 /usr/share/nagios4/htdocs
+```
+
+to:
+
+```text
+Alias /nagios /usr/share/nagios4/htdocs
+```
+
+Save the file and quit.
+
+To activate this change, disable the `nagios4` site first:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo a2dissite nagios4
+```
+
+Then copy the `/etc/nagios4/apache2.conf` file to the `/etc/apache2/sites-available` directory:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo cp /etc/nagios4/apache2.conf /etc/apache2/sites-available/nagios4.conf
+```
+
+Enable the configuration:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo a2ensite nagios4.conf
+```
+
+And reload Apache2:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo systemctl reload apache2
+```
+
+To test the change, enter `server01/nagios` into a browser.
+
+You can directly edit the `/etc/apache2/sites-enabled/nagios4.conf` file and then reload Apache2, without disabling the site first, but this makes it harder to keep track of changes and restore to a working state if something goes wrong. It is a good idea to always back up the file before making any changes, so you can quickly restore from it.
+
+
+## Working with Nagios users
+
+So far, the only user with access to Nagios is `nagiosadmin`. In the next steps, a `nagiosuser` will be created and configured to have viewing access to Nagios. On `server01`, enter in the terminal:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo htdigest -c /etc/nagios4/htdigest.users "Nagios4" nagiosuser
+```
+
+At this point, `nagiosuser` is created but no access has been defined. To define access, edit file `/etc/nagios4/cgi.cfg` and change the following line:
+
+```text
+authorized_for_system_information=nagiosadmin
+```
+
+to:
+
+```text
+authorized_for_system_information=nagiosadmin, nagiosuser
+```
+
+To allow the user to view global hosts and services, define access by changing
+these lines:
+
+```text
+authorized_for_all_services=nagiosadmin
+authorized_for_hosts=nagiosadmin
+```
+
+to
+
+```text
+authorized_for_all_services=nagiosadmin, nagiosuser
+authorized_for_all_hosts=nagiosadmin, nagiosuser
+```
+
+Save the file and quit, then reload the Nagios configuration:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo systemctl reload nagios4
+```
+
+To test it, navigate in a browser to `server01/nagios` and login as `nagiosuser`. Click on Hosts, Services links. You should be able to view both. Then look for System, Configuration links. When trying to access the Configuration, a "no permission to view information" message should be displayed.
+
+:::{note}
+When using the `htdigest` utility, use the `-c` option only when first creating
+a user. Omit the `-c` to change password afterwards. The `/etc/nagios4/cgi.cfg`
+has many options. Review the file for usage.
+:::
+
+
+## Working with resource objects
+
+Objects are definitions files for each one of the resources available in Nagios.
+Files are located in the `/etc/nagios4/objects` directory.
+
+The Nagios 4 package installs the standard Nagios monitoring plugins.
+These are located in directory `/usr/lib/nagios/plugins`. So far, the checks
+defined for the localhost in file `/etc/nagios4/objects/localhost.cfg` make use
+of these plugins. By default, Nagios is configured to check HTTP, disk space,
+SSH, current users, processes, and load on the localhost; as well as ping check
+the gateway.
+
+
+### Creating host config file for `server02`
+
+To create host config file for `server02`, on `server01`:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo cp /etc/nagios4/objects/localhost.cfg /etc/nagios4/conf.d/server02.cfg
+```
+
+Then, edit file `/etc/nagios4/conf.d/server02.cfg`. Change the host definition. Replace `address` with the IP address of `server02`. On existing definitions, replace `host_name` with `server02`:
+
+```text
+define host {
+      use              generic-host     ;Name of host template to use
+      host_name        server02         ;This host definition will inherit all variables that are defined
+      alias            server 02        ;in (or inherited by) the linux-server host template definition.
+      address          172.10.100.2
+}
+```
+
+Also, add a DNS check service definition by adding these lines:
+
+```text
+# Define a DNS check service on server02
+define service {
+      use                    local-service
+      host_name              server02
+      service_description    DNS
+      check_command          check_dns
+      notification_enabled   0
+}
+
+```
+
+Save the file and exit.
+
+When copying resource files to use as templates, be aware that this can create duplicate definitions. When you run a pre-flight check described in next section, errors and warnings will be reported. To avoid this, comment out the duplicate definitions.
+
+Before restarting the Nagios server, test the configuration.
+
+
+## Testing the Nagios configuration and troubleshooting
+
+When you make changes to the Nagios configuration, you can test the configuration before it is enabled. In this way you can make the necessary changes, in case of errors, before restarting the Nagios server.
+
+Still on `server01`, enter into the terminal:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo nagios4 -v /etc/nagios4/nagios.cfg
+```
+
+If no errors are found, restart the Nagios server:
+
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo systemctl restart nagios4
+```
+
+
+### Hostgroup definitions
+
+Now create a hostgroup definition, which is used to group one or more hosts together for easier configuration. In this step you will create a service definition for the MySQL check and a MySQL hostgroup definition. To install the MySQL server, run:
+
+```{terminal}
+:copy:
+:user: user
+:host: server02
+:dir: ~
+sudo apt install mysql-server
+```
+
+For the purpose of this guide, MySQL server has been installed on `server02`.
+
+```{seealso}
+* {ref}`install-mysql`
+* [MYSQL tutorial by tutorials24x7.com](https://www.tutorials24x7.com/mysql/how-to-install-mysql-8-on-ubuntu-2004-lts)
+* [MySQL official documentation](https://www.mysql.com)
+```
+
+Next, add a service definition for the MySQL check and the hostgroup `mysql-servers` definition. The service definition is added to the file `/etc/nagios4/conf.d/services_nagios2.cfg`:
+
+```text
+#check MySQL servers
+define service {
+             hostgroup_name            mysql-servers
+             service_description       MySQL
+             check_command             check_mysql_cmdlinecred!nagios!secret!$HOSTADRESS
+             use                       generic-service
+             notification_interval     0; set > 0 to be re-notified
+}
+```
+
+Add the `mysql-servers` definition by editing `/etc/nagios4/conf.d/hostgroups_nagios2.cfg`:
+
+```text
+#MySQL group definition
+define hostgroup {
+             hostgroup_name      mysql-servers
+             alias               MySQL  servers
+             members             localhost, server02
+}
+```
+
+### Nagios user authentication to MySQL
+
+The Nagios check needs to authenticate to MySQL. Add a Nagios user to MySQL on
+`server02`:
+
+```{terminal}
+:copy:
+:user: user
+:host: server02
+:dir: ~
 mysql -u root -p -e "create user nagios identified by 'secret';"
 ```
 
-:::{note}
-The `nagios` user will need to be added to all hosts in the **mysql-servers** hostgroup.
-:::
-
-Restart nagios to start checking the MySQL servers.
+Alternatively, you can log into MySQL and create the Nagios user. Replace `'secret'` with a password.
 
 ```{terminal}
 :copy:
-:user:
-:host:
-:dir:
-sudo systemctl restart nagios3.service
+:user: user
+:host: server02
+:dir: ~
+sudo mysql -u root -p
+mysql> CREATE USER 'nagios' IDENTIFIED BY 'secret';
+mysql> flush privileges;
+mysql> exit
 ```
 
-### Configure NRPE
+:::{note}
+The Nagios user will need to be added to all hosts in the `mysql-servers` hostgroup.
+:::
 
-Lastly configure NRPE to check the disk space on *server02*.
-    
-On `server01` add the service check to `/etc/nagios3/conf.d/server02.cfg`:
+Restart Nagios to start checking the MySQL servers. On `server01` run:
 
-```text    
-# NRPE disk check.
+```{terminal}
+:copy:
+:user: user
+:host: server01
+:dir: ~
+sudo systemctl restart nagios4
+```
+
+## NRPE configuration
+
+As a last step, configure NRPE to check disk space on `server02`.
+
+On `server01`, add the service check to `/etc/nagios4/conf.d/server02.cfg`:
+
+```text
+#NRPE disk check
 define service {
-        use                     generic-service
-        host_name               server02
-        service_description     nrpe-disk
-        check_command           check_nrpe_1arg!check_all_disks!172.18.100.101
+             use                  generic-service
+             host_name            server02
+             server_description   nrpe-disk-check
+             check_command        check_nrpe_1arg!check_all_disks!172.10.100.2
 }
 ```
 
-Now on `server02` edit `/etc/nagios/nrpe.cfg` changing:
+On `server02`, edit `/etc/nagios/nrpe.cfg`, changing:
 
-```text    
-allowed_hosts=172.18.100.100
+```text
+allowed_hosts=172.10.100.1
 ```
 
-And below, in the command definition area, add:
+Below, in the command definition area, add:
 
 ```text
 command[check_all_disks]=/usr/lib/nagios/plugins/check_disk -w 20% -c 10% -e
 ```
-    
-Finally, restart `nagios-nrpe-server`:
+
+While on `server02`, restart `nagios-nrpe-server`:
 
 ```{terminal}
 :copy:
-:user:
-:host:
-:dir:
+:user: user
+:host: server02
+:dir: ~
 sudo systemctl restart nagios-nrpe-server.service
 ```
-    
-Also, on `server01` restart Nagios:
+
+Finally, on `server01` restart Nagios:
 
 ```{terminal}
 :copy:
-:user:
-:host:
-:dir:
-sudo systemctl restart nagios3.service
+:user: user
+:host: server01
+:dir: ~
+sudo systemctl restart nagios4
 ```
-
-You should now be able to see the host and service checks in the Nagios CGI files. To access them, point a browser to `http://server01/nagios3`. You will then be prompted for the **`nagiosadmin`** username and password.
 
 ## Further reading
 
-This section has just scratched the surface of Nagios' features. The `nagios-plugins-extra` and `nagios-snmp-plugins` contain many more service checks.
+This guide is meant to serve as a stepping stone into Nagios Core 4.
 
-- For more information about Nagios, see [the Nagios website](https://www.nagios.org/).
+There are many more Nagios features and uses not covered here. There are many
+resources and tutorials available online. Some are listed below. This guide made
+use of previous installation instructions for Nagios 3:
 
-- The [Nagios Core Documentation](https://library.nagios.com/products/nagios-core/documentation/) and [Nagios Core 3 Documentation](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/toc.html) may also be useful.
-
-- They also provide a [list of books](https://www.nagios.org/about/propaganda/books-2/) related to Nagios and network monitoring.
-
-- The [Nagios Ubuntu Wiki](https://help.ubuntu.com/community/Nagios3) page also has more details.
+* For more information about Nagios and its features, visit the [Nagios website](https://www.nagios.com).
+* Also the [Nagios Core Documentation](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/4/en/whatsnew.html) and [Nagios Core 4 Documentation](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/4/en/).
+* Nagios website also offers a [list of books](https://www.nagios.org/about/propaganda/books-2/) related to Nagios, its administration and monitoring.

--- a/legacy/install-nagios-core-3.md
+++ b/legacy/install-nagios-core-3.md
@@ -1,0 +1,264 @@
+---
+myst:
+  html_meta:
+    description: Install and configure Nagios Core 3 for availability monitoring of essential servers and services across multiple Ubuntu systems.
+---
+
+(install-nagios-core-3)=
+# How to install and configure Nagios Core 3
+
+:::{note}
+Nagios Core 3 has been deprecated and is now replaced by Nagios Core 4. The `nagios3` package was last supported in Ubuntu 18.04 LTS (Bionic Beaver), so subsequent releases should use `nagios4` instead.
+:::
+
+The monitoring of essential servers and services is an important part of system administration. This guide walks through how to install and configure Nagios Core 3 for availability monitoring.
+
+The example in this guide uses two servers with {term}`hostnames <hostname>`: **`server01`** and **`server02`**. 
+
+`Server01` will be configured with Nagios to monitor services on itself and on `server02`, while `server02` will be configured to send data to `server01`.
+
+## Install `nagios3` on `server01`
+
+First, on `server01`, install the `nagios3` package by entering the following command into your terminal:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
+sudo apt install nagios3 nagios-nrpe-plugin
+```
+
+You will be asked to enter a password for the **`nagiosadmin`** user. The user's credentials are stored in `/etc/nagios3/htpasswd.users`. To change the `nagiosadmin` password, or add more users to the Nagios CGI scripts, use the `htpasswd` that is part of the `apache2-utils` package.
+
+For example, to change the password for the `nagiosadmin` user, enter:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
+sudo htpasswd /etc/nagios3/htpasswd.users nagiosadmin
+```
+
+To add a user:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
+sudo htpasswd /etc/nagios3/htpasswd.users steve
+```
+
+## Install `nagios-nrpe-server` on `server02`
+
+Next, on `server02` install the `nagios-nrpe-server` package. From a terminal on `server02` enter:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
+sudo apt install nagios-nrpe-server
+```
+
+:::{note}
+NRPE allows you to execute local checks on remote hosts. There are other ways of accomplishing this through other Nagios plugins, as well as other checks.
+:::
+
+## Configuration overview
+
+There are a couple of directories containing Nagios configuration and check files.
+
+- `/etc/nagios3`: Contains configuration files for the operation of the Nagios daemon, CGI files, hosts, etc.
+
+- `/etc/nagios-plugins`: Contains configuration files for the service checks.
+
+- `/etc/nagios`: On the remote host, contains the `nagios-nrpe-server` configuration files.
+
+- `/usr/lib/nagios/plugins/`: Where the check binaries are stored. To see the options of a check use the `-h` option. For example: `/usr/lib/nagios/plugins/check_dhcp -h`
+
+There are multiple checks Nagios can be configured to execute for any given host. For this example, Nagios will be configured to check disk space, {term}`DNS`, and a MySQL {term}`hostgroup`. The DNS check will be on `server02`, and the MySQL hostgroup will include both `server01` and `server02`.
+
+:::{note}
+See these guides for details on {ref}`setting up Apache <introduction-to-web-services>`, {ref}`Domain Name Service <install-dns>`, and {ref}`MySQL <install-mysql>`.
+:::
+
+Additionally, there are some terms that once explained will hopefully make understanding Nagios configuration easier:
+
+- *Host*: A server, workstation, network device, etc. that is being monitored.
+
+- *Host Group*: A group of similar hosts. For example, you could group all web servers, file server, etc.
+
+- *Service*: The service being monitored on the host, such as HTTP, DNS, NFS, etc.
+
+- *Service Group*: Allows you to group multiple services together. This is useful for grouping multiple HTTP for example.
+
+- *Contact*: Person to be notified when an event takes place. Nagios can be configured to send emails, SMS messages, etc.
+
+By default, Nagios is configured to check HTTP, disk space, SSH, current users, processes, and load on the **localhost**. Nagios will also ping check the **gateway**.
+
+Large Nagios installations can be quite complex to configure. It is usually best to start small, with one or two hosts, to get things configured the way you want before expanding.
+
+## Configure Nagios
+
+### Create host config file for server02
+
+First, create a **host** configuration file for `server02`. Unless otherwise specified, run all these commands on `server01`. In a terminal enter:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
+sudo cp /etc/nagios3/conf.d/localhost_nagios2.cfg \
+/etc/nagios3/conf.d/server02.cfg
+```
+
+:::{note}
+In all command examples, replace "`server01`", "`server02`", `172.18.100.100`, and `172.18.100.101` with the host names and IP addresses of your servers.
+:::
+
+### Edit the host config file    
+
+Next, edit `/etc/nagios3/conf.d/server02.cfg`:
+ 
+```text    
+define host{
+        use                     generic-host  ; Name of host template to use
+        host_name               server02
+        alias                   Server 02
+        address                 172.18.100.101
+}
+        
+# check DNS service.
+define service {
+        use                             generic-service
+        host_name                       server02
+        service_description             DNS
+        check_command                   check_dns!172.18.100.101
+}
+```
+
+Restart the Nagios daemon to enable the new configuration:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
+sudo systemctl restart nagio3.service
+```
+
+### Add service definition
+
+Now add a service definition for the MySQL check by adding the following to `/etc/nagios3/conf.d/services_nagios2.cfg`:
+
+```text    
+# check MySQL servers.
+define service {
+        hostgroup_name        mysql-servers
+        service_description   MySQL
+        check_command         check_mysql_cmdlinecred!nagios!secret!$HOSTADDRESS
+        use                   generic-service
+        notification_interval 0 ; set > 0 if you want to be renotified
+}
+```
+
+A **mysql-servers** hostgroup now needs to be defined. Edit `/etc/nagios3/conf.d/hostgroups_nagios2.cfg` and add the following:
+
+```text
+# MySQL hostgroup.
+define hostgroup {
+        hostgroup_name  mysql-servers
+                alias           MySQL servers
+                members         localhost, server02
+        }
+```
+
+The Nagios check needs to authenticate to MySQL. To add a `nagios` user to MySQL enter:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
+mysql -u root -p -e "create user nagios identified by 'secret';"
+```
+
+:::{note}
+The `nagios` user will need to be added to all hosts in the **mysql-servers** hostgroup.
+:::
+
+Restart nagios to start checking the MySQL servers.
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
+sudo systemctl restart nagios3.service
+```
+
+### Configure NRPE
+
+Lastly configure NRPE to check the disk space on *server02*.
+    
+On `server01` add the service check to `/etc/nagios3/conf.d/server02.cfg`:
+
+```text    
+# NRPE disk check.
+define service {
+        use                     generic-service
+        host_name               server02
+        service_description     nrpe-disk
+        check_command           check_nrpe_1arg!check_all_disks!172.18.100.101
+}
+```
+
+Now on `server02` edit `/etc/nagios/nrpe.cfg` changing:
+
+```text    
+allowed_hosts=172.18.100.100
+```
+
+And below, in the command definition area, add:
+
+```text
+command[check_all_disks]=/usr/lib/nagios/plugins/check_disk -w 20% -c 10% -e
+```
+    
+Finally, restart `nagios-nrpe-server`:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
+sudo systemctl restart nagios-nrpe-server.service
+```
+    
+Also, on `server01` restart Nagios:
+
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
+sudo systemctl restart nagios3.service
+```
+
+You should now be able to see the host and service checks in the Nagios CGI files. To access them, point a browser to `http://server01/nagios3`. You will then be prompted for the **`nagiosadmin`** username and password.
+
+## Further reading
+
+This section has just scratched the surface of Nagios' features. The `nagios-plugins-extra` and `nagios-snmp-plugins` contain many more service checks.
+
+- For more information about Nagios, see [the Nagios website](https://www.nagios.org/).
+
+- The [Nagios Core Documentation](https://library.nagios.com/products/nagios-core/documentation/) and [Nagios Core 3 Documentation](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/toc.html) may also be useful.
+
+- They also provide a [list of books](https://www.nagios.org/about/propaganda/books-2/) related to Nagios and network monitoring.
+
+- The [Nagios Ubuntu Wiki](https://help.ubuntu.com/community/Nagios3) page also has more details.


### PR DESCRIPTION
### Description

Please provide a clear and concise description of your changes.

- What does this pull request accomplish?
  It updates the "Install Nagios" page from Nagios Core 3 to Nagiost Core 4. This work was originally proposed by @costarican in issue #59, and I put this into PR #387 alongside a bunch of other changes. PR 387 will now be closed in favour of this PR.

- Why is the change needed?
  Nagios Core 3 was last supported in Bionic. The previous PR I submitted with these changes is now very out-of-date with the main branch, so I'm bringing this over to a fresh one. The rest of the changes in 387 were addressed in other PRs, this is the final step. I have also updated the formatting to match more recent changes.

---

### Related issue

- Fixes: #41 and #59

---

### AI usage

If you used AI to assist you in the creation of this PR, please let us know:

N/A, this was done by hand

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
- [x] I have disclosed my usage of AI

---

### Additional Notes (Optional)

We were originally blocked on the original PR by the fact that the author had not signed the CLA. Since then, it was confirmed by the tech board that the CLA is not required on Ubuntu projects, and therefore this is no longer a blocker.

A copy of the Nagios 3 page has been stored in our legacy section. No redirects are needed since Nagios 4 is the current default.

---

Thank you to @costarican for contributing this update to the Ubuntu Server documentation!
