### PR TITLE
Fix feedback button

### DIFF
--- a/docs/_static/js/github_issue_links.js
+++ b/docs/_static/js/github_issue_links.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', function() {
     link.classList.add("github-issue-link");
     link.text = "Give feedback";
     // use the issue template in the .github/ISSUE_TEMPLATE/feedback.yml file
-    link.href = githubUrl + "issues/new?template=feedback.yml";
+    link.href = githubUrl + "/issues/new?template=feedback.yml";
     link.target = "_blank";
 
     const div = document.createElement("div");


### PR DESCRIPTION
### Description

Currently, the URL in the Feedback button renders as `https://github.com/canonical/ubuntu-server-documentationissues/new?template=feedback.yml` 
This PR fixes it.

---
### Related issue

N/A

---

### AI usage

N/A

---

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [ ] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
- [x] I have disclosed my usage of AI

---

### Additional Notes (Optional)

N/A

