### PR TITLE
Fix broken linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -255,6 +255,7 @@ linkcheck_ignore = [
     "https://people.freedesktop.org/*",
     "https://www.squid-cache.org/Doc/config/",
     "https://tunnelblick.net/*",
+    "https://graylog.org/",
 ]
 
 # A regex list of URLs where anchors are ignored by "make linkcheck"


### PR DESCRIPTION
### Description

Add Graylog to list of ignored URLs. The link still works but they are blocking bots, so causing the linkchecker to fail.

There is an Ubuntu Archive link that's also failing but that one is likely to clear up. If it's still on the list next week, I'll add that to the ignore list as well.


### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
- [x] I have disclosed my usage of AI

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
