### PR TITLE
[chore] Add URL to linkcheck anchors ignore list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -256,6 +256,7 @@ linkcheck_ignore = [
     "https://www.squid-cache.org/Doc/config/",
     "https://tunnelblick.net/*",
     "https://graylog.org/",
+    "https://www.dedoimedo.com/computers/crash-analyze.html",
 ]
 
 # A regex list of URLs where anchors are ignored by "make linkcheck"


### PR DESCRIPTION
### Description

- Add new failing link to ignore list

- A new site is blocking the linkcheck bot. It still works when I check the link manually in my browser, so not genuinely broken.

Did not use AI for this PR

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
- [x] I have disclosed my usage of AI

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
