### PR TITLE
Fix failing linkchecker

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -257,6 +257,11 @@ linkcheck_ignore = [
     "https://tunnelblick.net/*",
     "https://graylog.org/",
     "https://www.dedoimedo.com/computers/crash-analyze.html",
+    "https://askubuntu.com/*",
+    "https://docs.aws.amazon.com/*",
+    "https://docs.nvidia.com/*",
+    "https://docs.amd.com",
+    "https://www.rapid7.com/products/siem/",
 ]
 
 # A regex list of URLs where anchors are ignored by "make linkcheck"


### PR DESCRIPTION
### Description

The linkchecker is currently failing on several links that are working in the browser but blocking bot traffic. This PR adds those sites to the ignore list.

### Checklist

- [x] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [x] My pull request is linked to an existing issue (if applicable).
- [x] I have tested my changes, and they work as expected.
- [x] I have disclosed my usage of AI

---

### Additional Notes (Optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions,
screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Server documentation!
