### PR TITLE
reference/other-tools: include rust-coreutils in sudo-rs

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -52,6 +52,8 @@ Conffiles
 conffiles
 configurability
 connectionless
+Coreutils
+coreutils
 CRLs
 Cron
 cron
@@ -316,6 +318,7 @@ usermode
 userspace
 usr
 UUIDs
+uutils
 UVtool
 Valgrind
 validator

--- a/docs/reference/other-tools/sudo-rs.md
+++ b/docs/reference/other-tools/sudo-rs.md
@@ -1,13 +1,58 @@
 ---
 myst:
   html_meta:
-    description: "Reference documentation for sudo-rs outlining differences to the former sudo.ws, to guide users of Ubuntu Server on the new implementation."
+    description: "Reference documentation for migrated tools outlining differences to the former, to guide users of Ubuntu Server on the new implementations."
 ---
 
-(sudo-rs)=
-# sudo-rs
+# Migrated tools
 
-This page serves as a reference for the key differences between `sudo.ws` and `sudo-rs`.
+The “oxidisation” of Ubuntu (see [Ubuntu Discourse](https://discourse.ubuntu.com/t/carefully-but-purposefully-oxidising-ubuntu/56995)) has changed the providers of a number of packages that are installed by default.
+This page provides guidance for Ubuntu Server users on the new implementations
+
+(rust-coreutils)=
+## rust-coreutils
+
+uutils is the default coreutils provider as of Ubuntu 25.10. This section lists
+helpful resources and tips regarding the migration.
+
+Refer to the [uutils Coreutils Documentation](https://uutils.org/coreutils/docs/index.html) for information about uutils.
+
+### Exceptions per releases
+
+Due to known incompatibilities, some utilities in `rust-coreutils` are still
+provided by GNU for the Ubuntu 25.10 and 26.04 releases. Redirected utilities
+per release are as follows:
+
+| Release | Utilities still provided by GNU |
+|---|---|
+| **Ubuntu 25.10** ([reference][ubuntu-25.10-reference]) | `chmod`, `chown`, `cp`, `df`, `mv`, `rm`, `true` |
+| **Ubuntu 26.04** ([reference][ubuntu-26.04-reference]) | `cp`, `df`, `mv`, `rm`, `true` |
+| **Ubuntu 26.10 and later** | — |
+
+[ubuntu-25.10-reference]: https://git.launchpad.net/ubuntu/+source/coreutils-from/tree/debian/coreutils-from-uutils.links?h=ubuntu/questing-devel
+[ubuntu-26.04-reference]: https://git.launchpad.net/ubuntu/+source/coreutils-from/tree/debian/coreutils-from-uutils.links?h=ubuntu/resolute-devel
+
+### Changing provider
+
+The installed `coreutils-from-*` package determines which coreutils provider is
+used on the system.
+
+**To switch to GNU coreutils:**
+
+```shell
+sudo apt install coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential
+```
+
+**To switch to back to rust-coreutils:**
+
+```shell
+sudo apt install coreutils-from-uutils coreutils-from-gnu- --allow-remove-essential
+```
+
+(sudo-rs)=
+## sudo-rs
+
+This section serves as a reference for the key differences between `sudo.ws` and `sudo-rs`.
 
 Note: Both projects are under active development, so it is not possible to maintain a fully up-to-date list of differences.
 This is a list of major differences as of the Ubuntu 25.10 and 26.04 releases, to help users upgrading to those.
@@ -16,7 +61,7 @@ For the most accurate and current information, refer to
 `sudo-rs --help` for a list of supported options in your installed version.
 Refer to `man sudoers-rs` for the `/etc/sudoers` configuration options supported by `sudo-rs`.
 
-## Differences
+### Differences
 
 1. Start with the official documentation from the `sudo-rs` project.
 

--- a/docs/reference/other-tools/sudo-rs.md
+++ b/docs/reference/other-tools/sudo-rs.md
@@ -6,12 +6,14 @@ myst:
 
 # System utility replacements
 
-Starting with Ubuntu 25.10, the "oxidization" of Ubuntu (see [Ubuntu Discourse][oxiziding-ubuntu-reference]) changed the providers of the system utilities
-`coreutils` and `sudo` to new Rust-based implementations. Previous Ubuntu
-releases retain their existing default providers.
+Starting with Ubuntu 25.10, the "oxidization" of Ubuntu (see [Ubuntu
+Discourse](https://discourse.ubuntu.com/t/carefully-but-purposefully-oxidising-ubuntu/56995))
+changed the providers of the system utilities `coreutils` and `sudo` to new
+Rust-based implementations. Previous Ubuntu releases retain their existing
+default providers.
 
-- **`coreutils`**: changed from [GNU Coreutils][gnu-coreutils-manual-reference] to [uutils Coreutils][uutils-coreutils-manual-reference]
-- **`sudo`**: changed from [`sudo.ws`][sudo-ws-manual-reference] to [`sudo-rs`][sudo-rs-project-reference]
+- **`coreutils`**: changed from [GNU Coreutils](https://www.gnu.org/software/coreutils/manual) to [uutils Coreutils](https://uutils.org/coreutils/docs)
+- **`sudo`**: changed from [`sudo.ws`](https://www.sudo.ws/docs/man/sudo.man/) to [`sudo-rs`](https://github.com/trifectatechfoundation/sudo-rs)
 
 For most users, no changes are required for normal usage. The new Rust-based
 implementations are intended to be drop-in replacements for the existing
@@ -24,12 +26,6 @@ where they are the default providers. In newer releases where the Rust-based
 implementations are the default, **GNU Coreutils and sudo.ws remain available
 as providers**, while the Rust-based implementations are the primary ones
 going forward.
-
-[oxiziding-ubuntu-reference]: https://discourse.ubuntu.com/t/carefully-but-purposefully-oxidising-ubuntu/56995
-[uutils-coreutils-manual-reference]: https://uutils.org/coreutils/docs
-[gnu-coreutils-manual-reference]: https://www.gnu.org/software/coreutils/manual
-[sudo-ws-manual-reference]: https://www.sudo.ws/docs/man/sudo.man/
-[sudo-rs-project-reference]: https://github.com/trifectatechfoundation/sudo-rs
 
 (rust-coreutils)=
 ## rust-coreutils
@@ -86,13 +82,21 @@ providers.
 
 **To switch to GNU Coreutils:**
 
-```shell
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
 sudo apt install coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential
 ```
 
 **To switch back to `rust-coreutils`:**
 
-```shell
+```{terminal}
+:copy:
+:user:
+:host:
+:dir:
 sudo apt install coreutils-from-uutils coreutils-from-gnu- --allow-remove-essential
 ```
 

--- a/docs/reference/other-tools/sudo-rs.md
+++ b/docs/reference/other-tools/sudo-rs.md
@@ -8,9 +8,10 @@ myst:
 
 Starting with Ubuntu 25.10, the "oxidization" of Ubuntu (see [Ubuntu Discourse][oxiziding-ubuntu-reference]) changed the providers of the system utilities
 `coreutils` and `sudo` to new Rust-based implementations. Previous Ubuntu
-releases are unaffected.
-- `coreutils`: changed from [GNU Coreutils][gnu-coreutils-manual-reference] to [uutils Coreutils][uutils-coreutils-manual-reference]
-- `sudo`: changed from [`sudo.ws`][sudo-ws-manual-reference] to [`sudo-rs`][sudo-rs-project-reference]
+releases retain their existing default providers.
+
+- **`coreutils`**: changed from [GNU Coreutils][gnu-coreutils-manual-reference] to [uutils Coreutils][uutils-coreutils-manual-reference]
+- **`sudo`**: changed from [`sudo.ws`][sudo-ws-manual-reference] to [`sudo-rs`][sudo-rs-project-reference]
 
 For most users, no changes are required for normal usage. The new Rust-based
 implementations are intended to be drop-in replacements for the existing
@@ -20,8 +21,9 @@ considerations that may affect specific use cases.
 
 GNU Coreutils and `sudo.ws` continue to receive maintenance in Ubuntu releases
 where they are the default providers. In newer releases where the Rust-based
-implementations are the default, they remain available as providers, while
-the Rust-based implementations are the primary ones going forward.
+implementations are the default, **GNU Coreutils and sudo.ws remain available
+as providers**, while the Rust-based implementations are the primary ones
+going forward.
 
 [oxiziding-ubuntu-reference]: https://discourse.ubuntu.com/t/carefully-but-purposefully-oxidising-ubuntu/56995
 [uutils-coreutils-manual-reference]: https://uutils.org/coreutils/docs
@@ -34,17 +36,18 @@ the Rust-based implementations are the primary ones going forward.
 
 This section lists helpful resources and tips regarding the new Rust-based
 implementation of `coreutils`, provided by the `rust-coreutils` package.
-The `rust-coreutils` package is available for install on Ubuntu 24.04 LTS and
-later, but GNU Coreutils remains the default provider on Ubuntu 24.04 LTS.
+The `rust-coreutils` package is available for installation on Ubuntu 24.04 LTS
+and later.
 
 Refer to the [uutils Coreutils Documentation](https://uutils.org/coreutils/docs/index.html) for information about its usage.
 
 ### Release-specific exceptions
 
 The `rust-coreutils` package provides implementations of all `coreutils`
-utilities (also available through its `coreutils` multi-call binary). However,
-the `coreutils-from-<provider>` packages control which implementation is used
-by the system utility commands such as `cp` and `chmod`.
+utilities, which can also be invoked through its `coreutils` multi-call binary.
+However, starting with Ubuntu 25.10, the `coreutils-from-<provider>` packages
+control which implementation is used by the standard utility commands such as
+`cp` and `chmod`.
 
 Due to known incompatibilities, `coreutils-from-uutils` configures some
 commands to continue using GNU Coreutils in Ubuntu 25.10 and Ubuntu 26.04 LTS.
@@ -60,22 +63,23 @@ commands to continue using GNU Coreutils in Ubuntu 25.10 and Ubuntu 26.04 LTS.
 Although the `rust-coreutils` package is available in Ubuntu 24.04 LTS, it
 cannot be configured as the default `coreutils`. The
 `coreutils-from-<provider>` packages required to switch the provider are only
-available starting with Ubuntu 26.04 LTS.
+available starting with Ubuntu 25.10.
 :::
 
-### Switching the coreutils provider (Ubuntu 26.04 LTS and later)
+### Switching the coreutils provider (Ubuntu 25.10 and later)
 
 The `coreutils-from-<provider>` packages are available starting with Ubuntu
-26.04 LTS and determine which coreutils provider is used on the system. By
+25.10 and determine which coreutils provider is used on the system. By
 default, the `coreutils-from-uutils` package is installed.
 
 When switching providers, the `--allow-remove-essential` option is required
-because `apt` sees the currently active `coreutils` package as Essential.
+because `apt` sees the currently active `coreutils` package as `Essential`.
 Switching providers therefore requires explicitly allowing `apt` to remove that
 package.
 
-:::{note} `update-alternatives` is not currently suitable for switching between
-GNU Coreutils and uutils Coreutils, as alternatives are not safe for Essential
+:::{note}
+`update-alternatives` is not currently suitable for switching between GNU
+Coreutils and uutils Coreutils, as alternatives are not safe for `Essential`
 packages. Instead, use the `coreutils-from-<provider>` packages to switch
 providers.
 :::
@@ -91,6 +95,27 @@ sudo apt install coreutils-from-gnu coreutils-from-uutils- --allow-remove-essent
 ```shell
 sudo apt install coreutils-from-uutils coreutils-from-gnu- --allow-remove-essential
 ```
+
+### `build-essential` dependency
+
+The `build-essential` package has a direct dependency on the package providing
+the default `coreutils` implementation. This ensures that the coreutils
+implementation used in the Ubuntu archive build environment is consistent.
+
+In Ubuntu 25.10 and later, this dependency resolves to `coreutils-from-uutils`.
+In earlier releases, it resolves to the package providing GNU Coreutils.
+This dependency is intentionally specific to `build-essential`: allowing either
+GNU Coreutils or uutils Coreutils could result in build failures or
+inconsistent build behavior due to differences between the two implementations.
+
+Some packages also declare a dependency on `build-essential` without requiring
+its full set of build tools. This can result in an indirect dependency on
+`coreutils-from-uutils` in Ubuntu 25.10 and later.
+
+:::{note}
+As a result, these packages may currently conflict with `coreutils-from-gnu`
+when switching the coreutils provider.
+:::
 
 (sudo-rs)=
 ## sudo-rs

--- a/docs/reference/other-tools/sudo-rs.md
+++ b/docs/reference/other-tools/sudo-rs.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Reference documentation for Ubuntu Server’s Rust-based replacements for sudo and GNU coreutils, highlighting differences, release-specific exceptions, and important changes for users"
+    description: "Reference page for Ubuntu’s Rust-based replacements for sudo and GNU coreutils, highlighting differences, release-specific exceptions, and important changes."
 ---
 
 # System utility replacements

--- a/docs/reference/other-tools/sudo-rs.md
+++ b/docs/reference/other-tools/sudo-rs.md
@@ -1,49 +1,77 @@
 ---
 myst:
   html_meta:
-    description: "Reference documentation for migrated tools outlining differences to the former, to guide users of Ubuntu Server on the new implementations."
+    description: "Reference documentation for Ubuntu Server’s Rust-based replacements for sudo and GNU coreutils, highlighting differences, release-specific exceptions, and important changes for users"
 ---
 
-# Migrated tools
+# System utility replacements
 
-The “oxidisation” of Ubuntu (see [Ubuntu Discourse](https://discourse.ubuntu.com/t/carefully-but-purposefully-oxidising-ubuntu/56995)) has changed the providers of a number of packages that are installed by default.
-This page provides guidance for Ubuntu Server users on the new implementations
+Starting with Ubuntu 25.10, the "oxidization" of Ubuntu (see [Ubuntu Discourse][oxiziding-ubuntu-reference]) changed the providers of the system utilities
+`coreutils` and `sudo` to new Rust-based implementations. Previous Ubuntu
+releases are unaffected.
+- `coreutils`: changed from [GNU Coreutils][gnu-coreutils-manual-reference] to [uutils Coreutils][uutils-coreutils-manual-reference]
+- `sudo`: changed from [sudo.ws][sudo-ws-manual-reference] to [sudo-rs][sudo-rs-project-reference]
+
+This page provides guidance on the new implementations.
+
+[oxiziding-ubuntu-reference]: https://discourse.ubuntu.com/t/carefully-but-purposefully-oxidising-ubuntu/56995
+[uutils-coreutils-manual-reference]: https://uutils.org/coreutils/docs
+[gnu-coreutils-manual-reference]: https://www.gnu.org/software/coreutils/manual
+[sudo-ws-manual-reference]: https://www.sudo.ws/docs/man/sudo.man/
+[sudo-rs-project-reference]: https://github.com/trifectatechfoundation/sudo-rs
 
 (rust-coreutils)=
 ## rust-coreutils
 
-uutils is the default coreutils provider as of Ubuntu 25.10. This section lists
-helpful resources and tips regarding the migration.
+This section lists helpful resources and tips regarding the new Rust-based
+implementation of `coreutils`, provided by the `rust-coreutils` package.
 
-Refer to the [uutils Coreutils Documentation](https://uutils.org/coreutils/docs/index.html) for information about uutils.
+Refer to the [uutils Coreutils Documentation](https://uutils.org/coreutils/docs/index.html) for information about its usage.
 
-### Exceptions per releases
+### Release-specific exceptions
 
-Due to known incompatibilities, some utilities in `rust-coreutils` are still
-provided by GNU for the Ubuntu 25.10 and 26.04 releases. Redirected utilities
-per release are as follows:
+Due to known incompatibilities, some utilities continue to be provided by GNU
+Coreutils instead of `rust-coreutils` in Ubuntu 25.10 and Ubuntu 26.04 LTS.
+The utilities provided by GNU Coreutils in each release are as follows:
 
-| Release | Utilities still provided by GNU |
+| Release | Utilities provided by GNU Coreutils |
 |---|---|
-| **Ubuntu 25.10** ([reference][ubuntu-25.10-reference]) | `chmod`, `chown`, `cp`, `df`, `mv`, `rm`, `true` |
-| **Ubuntu 26.04** ([reference][ubuntu-26.04-reference]) | `cp`, `df`, `mv`, `rm`, `true` |
-| **Ubuntu 26.10 and later** | — |
+| **Ubuntu 24.04 LTS and earlier** | **All** |
+| **Ubuntu 25.10** | `chmod`, `chown`, `cp`, `df`, `mv`, `rm`, `true` |
+| **Ubuntu 26.04 LTS** | `cp`, `df`, `mv`, `rm`, `true` |
+| **Ubuntu 26.10 and later** | **None** |
 
-[ubuntu-25.10-reference]: https://git.launchpad.net/ubuntu/+source/coreutils-from/tree/debian/coreutils-from-uutils.links?h=ubuntu/questing-devel
-[ubuntu-26.04-reference]: https://git.launchpad.net/ubuntu/+source/coreutils-from/tree/debian/coreutils-from-uutils.links?h=ubuntu/resolute-devel
+:::{note}
+Although the `rust-coreutils` package is available in Ubuntu 24.04 LTS, it
+cannot be configured as the default `coreutils`. The
+`coreutils-from-<provider>` packages required to switch the provider are only
+available starting with Ubuntu 26.04 LTS.
+:::
 
-### Changing provider
+### Switching the coreutils provider (Ubuntu 26.04 LTS and later)
 
-The installed `coreutils-from-*` package determines which coreutils provider is
-used on the system.
+The `coreutils-from-<provider>` packages are available starting with Ubuntu
+26.04 LTS and determine which coreutils provider is used on the system. By
+default, the `coreutils-from-uutils` package is installed.
 
-**To switch to GNU coreutils:**
+When switching providers, the `--allow-remove-essential` option is required
+because `apt` sees the currently active `coreutils` package as Essential.
+Switching providers therefore requires explicitly allowing `apt` to remove that
+package.
+
+:::{note} `update-alternatives` is not currently suitable for switching between
+GNU Coreutils and uutils Coreutils, as alternatives are not safe for Essential
+packages. Instead, use the `coreutils-from-<provider>` packages to switch
+providers.
+:::
+
+**To switch to GNU Coreutils:**
 
 ```shell
 sudo apt install coreutils-from-gnu coreutils-from-uutils- --allow-remove-essential
 ```
 
-**To switch to back to rust-coreutils:**
+**To switch back to `rust-coreutils`:**
 
 ```shell
 sudo apt install coreutils-from-uutils coreutils-from-gnu- --allow-remove-essential

--- a/docs/reference/other-tools/sudo-rs.md
+++ b/docs/reference/other-tools/sudo-rs.md
@@ -10,9 +10,18 @@ Starting with Ubuntu 25.10, the "oxidization" of Ubuntu (see [Ubuntu Discourse][
 `coreutils` and `sudo` to new Rust-based implementations. Previous Ubuntu
 releases are unaffected.
 - `coreutils`: changed from [GNU Coreutils][gnu-coreutils-manual-reference] to [uutils Coreutils][uutils-coreutils-manual-reference]
-- `sudo`: changed from [sudo.ws][sudo-ws-manual-reference] to [sudo-rs][sudo-rs-project-reference]
+- `sudo`: changed from [`sudo.ws`][sudo-ws-manual-reference] to [`sudo-rs`][sudo-rs-project-reference]
 
-This page provides guidance on the new implementations.
+For most users, no changes are required for normal usage. The new Rust-based
+implementations are intended to be drop-in replacements for the existing
+utilities, so existing commands and usage should generally continue to work
+as before. This page describes known differences, incompatibilities, and other
+considerations that may affect specific use cases.
+
+GNU Coreutils and `sudo.ws` continue to receive maintenance in Ubuntu releases
+where they are the default providers. In newer releases where the Rust-based
+implementations are the default, they remain available as providers, while
+the Rust-based implementations are the primary ones going forward.
 
 [oxiziding-ubuntu-reference]: https://discourse.ubuntu.com/t/carefully-but-purposefully-oxidising-ubuntu/56995
 [uutils-coreutils-manual-reference]: https://uutils.org/coreutils/docs
@@ -25,16 +34,22 @@ This page provides guidance on the new implementations.
 
 This section lists helpful resources and tips regarding the new Rust-based
 implementation of `coreutils`, provided by the `rust-coreutils` package.
+The `rust-coreutils` package is available for install on Ubuntu 24.04 LTS and
+later, but GNU Coreutils remains the default provider on Ubuntu 24.04 LTS.
 
 Refer to the [uutils Coreutils Documentation](https://uutils.org/coreutils/docs/index.html) for information about its usage.
 
 ### Release-specific exceptions
 
-Due to known incompatibilities, some utilities continue to be provided by GNU
-Coreutils instead of `rust-coreutils` in Ubuntu 25.10 and Ubuntu 26.04 LTS.
-The utilities provided by GNU Coreutils in each release are as follows:
+The `rust-coreutils` package provides implementations of all `coreutils`
+utilities (also available through its `coreutils` multi-call binary). However,
+the `coreutils-from-<provider>` packages control which implementation is used
+by the system utility commands such as `cp` and `chmod`.
 
-| Release | Utilities provided by GNU Coreutils |
+Due to known incompatibilities, `coreutils-from-uutils` configures some
+commands to continue using GNU Coreutils in Ubuntu 25.10 and Ubuntu 26.04 LTS.
+
+| Release | Utilities configured to use GNU Coreutils |
 |---|---|
 | **Ubuntu 24.04 LTS and earlier** | **All** |
 | **Ubuntu 25.10** | `chmod`, `chown`, `cp`, `df`, `mv`, `rm`, `true` |


### PR DESCRIPTION
### Description

This pull request adds necessary context for `rust-coreutils` in the Ubuntu Server docs, including how to switch to GNU and which tools are still using GNU in specific releases.

It provides a reference point for users coming from previous LTS versions where GNU was the coreutils provider.

---

### Related issue

- Fixes: #774 

---

### Checklist

- [X] I have read and followed the [Ubuntu Server contributing guide](https://ubuntu.com/server/docs/contributing/).
- [X] My pull request is linked to an existing issue (if applicable).
- [X] I have tested my changes, and they work as expected.
- [X] I have disclosed my usage of AI

---

### Additional Notes (Optional)

WIP: this PR intentionally does not restructure or rename the current `sudo-rs.md` file. The appropriate formatting is to be discussed.
