### PR TITLE
typo in virtual-machine-manager.md

### DIFF
--- a/docs/how-to/virtualisation/virtual-machine-manager.md
+++ b/docs/how-to/virtualisation/virtual-machine-manager.md
@@ -113,8 +113,6 @@ Similarly to `virt-manager`, `virt-viewer` can also connect to a remote host usi
 virt-viewer -c qemu+ssh://virtnode1.mydomain.com/system <guestname>
 ```
 
-Be sure to replace `web_devel` with the appropriate virtual machine name.
-
 If configured to use a **bridged** network interface, you can also set up SSH access to the virtual machine.
 
 ## virt-install


### PR DESCRIPTION
This line is no longer needed as the example in the CLI code block is now generic. (i.e. use <guestname>) and no longer mentions "web_devel".